### PR TITLE
#15: Fix dev mode to work natively and in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Format: **WHAT** changed, **WHY** it changed, and any **REASONING** behind decis
 ## [Unreleased]
 
 ### Fixed
+- **Dev mode works natively and in Docker** (#15)
+  - Vite proxy target now configurable via `VITE_BACKEND_TARGET` environment variable
+  - Native dev defaults to `http://localhost:8080` (backend `make start` port)
+  - Docker dev sets `VITE_BACKEND_TARGET=http://backend:80` in compose.yml
+  - Dev mode continues to have no CORS restrictions (permissive for browser extensions)
+
+**WHY**: The hardcoded `http://backend:80` proxy target only worked inside Docker. Native development (frontend `npm run dev` + backend `make start`) requires routing to `localhost:8080`.
+
 - **Frontend local media playback** (#13)
   - Player now rewrites `/local/` URLs to use backend API origin (needed for dev where frontend/backend ports differ)
   - Fixed `scrollIntoView` timing bug using Svelte's `tick()` instead of arbitrary `setTimeout`

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -2,6 +2,11 @@ import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import sveltePreprocess from 'svelte-preprocess'
 
+// Detect if running inside Docker (backend hostname resolves) or natively
+// In Docker: backend service is at http://backend:80
+// Native dev: backend is at http://localhost:8080
+const BACKEND_TARGET = process.env.VITE_BACKEND_TARGET || 'http://localhost:8080'
+
 export default defineConfig({
   plugins: [
     svelte({
@@ -9,16 +14,17 @@ export default defineConfig({
     }),
   ],
   server: {
+    host: '0.0.0.0',
     proxy: {
       // Proxy API requests to backend - avoids CORS/PNA issues in dev
       '/api': {
-        target: 'http://backend:80',
+        target: BACKEND_TARGET,
         changeOrigin: true,
         rewrite: (path) => path.replace(/^\/api/, ''),
       },
       // Proxy local media files to backend
       '/local': {
-        target: 'http://backend:80',
+        target: BACKEND_TARGET,
         changeOrigin: true,
       },
     },

--- a/infra/development/compose.yml
+++ b/infra/development/compose.yml
@@ -53,6 +53,8 @@ services:
       - VITE_API_HOST=${VITE_API_HOST}
       - VITE_API_PORT=${VITE_API_PORT}
       - VITE_API_PREFIX=${VITE_API_PREFIX}
+      # Backend target for Vite proxy (Docker service hostname)
+      - VITE_BACKEND_TARGET=http://backend:80
     volumes:
       - ../../frontend/src:/frontend/src
       - ../../frontend/public:/frontend/public


### PR DESCRIPTION
## Summary
- Vite proxy target now configurable via `VITE_BACKEND_TARGET` environment variable
- Native dev defaults to `http://localhost:8080` (backend `make start` port)
- Docker dev sets `VITE_BACKEND_TARGET=http://backend:80` in compose.yml
- Dev mode continues to have no CORS restrictions (permissive for browser extensions)

## Problem
The hardcoded `http://backend:80` proxy target only worked inside Docker. Native development (frontend `npm run dev` + backend `make start`) was broken because `backend` hostname doesn't resolve on the host machine.

## Solution
Make the proxy target configurable with a sensible default for native dev:
- `VITE_BACKEND_TARGET` env var controls where Vite proxies requests
- Default: `http://localhost:8080` for native development
- Docker compose sets it to `http://backend:80` for containerized dev

## CORS Configuration
Dev mode has no CORS restrictions (verified existing config):
- Backend CORS middleware: `allow_origins=["*"]` with all methods/headers
- Private Network Access header enabled for Chrome localhost requests
- Vite proxy handles routing, avoiding CORS issues from browser perspective

## Test plan
- [ ] Run backend natively: `cd backend && make start`
- [ ] Run frontend natively: `cd frontend && npm run dev`
- [ ] Verify search and playback work
- [ ] Run Docker dev: `cd infra && make dev-run`
- [ ] Verify search and playback work in Docker mode

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)