### PR TITLE
#23: Add regression tests for single-item RSS parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ Format: **WHAT** changed, **WHY** it changed, and any **REASONING** behind decis
 **REASONING**: Placed in `sources/` directory (separate from `collection/`) because it represents a different abstraction level. The adapter doesn't touch the database directly - it produces files + RSS that existing `collection/feed.py` can ingest. Uses yt-dlp with no cookies by default (privacy-respecting).
 
 ### Fixed
+- **Single-item RSS feeds now parse correctly** (#23)
+  - Added `_normalize_items()` helper to handle xmltodict dict vs list edge case
+  - When RSS has exactly one `<item>`, xmltodict returns a dict instead of list
+  - New helper normalizes both cases to always return a list
+  - Added 14 regression tests to prevent re-introduction
+  - RSS fixture files (single, multi, empty) for deterministic testing
+
+**WHY**: Podcasts with exactly one episode would fail to parse, breaking import for new or limited-episode feeds. This is a common edge case in RSS parsing.
+
+**REASONING**: Test-driven fix locks in the behavior permanently. The `TestXmltodictBehavior` tests document the underlying library behavior we're protecting against.
+
 - **Dev mode works natively and in Docker** (#15)
   - Vite proxy target now configurable via `VITE_BACKEND_TARGET` environment variable
   - Native dev defaults to `http://localhost:8080` (backend `make start` port)

--- a/backend/src/voogle/collection/feed.py
+++ b/backend/src/voogle/collection/feed.py
@@ -63,6 +63,18 @@ def _episode_guid(guid: dict | str) -> str:
     return guid["#text"] if isinstance(guid, dict) else guid
 
 
+def _normalize_items(channel_info: dict) -> list[dict]:
+    """Normalize RSS items to a list.
+
+    xmltodict returns a dict for single <item>, list for multiple.
+    This normalizes both cases to always return a list.
+    """
+    items = channel_info.get("item", [])
+    if isinstance(items, dict):
+        return [items]
+    return items
+
+
 def _read_channel_feed(url: str) -> dict | None:
     try:
         channel_info = xmltodict.parse(requests.get(url).content)
@@ -101,7 +113,7 @@ def read_episodes(channel: models.Channel) -> list[models.Episode]:
     if feed is None:
         return []
     episodes: list[models.Episode] = []
-    for ep in feed["rss"]["channel"]["item"]:
+    for ep in _normalize_items(feed["rss"]["channel"]):
         if ep.get("itunes:episodeType", None) not in ["bonus", "trailer"]:
             title = ep.get("title", None)
             if title:

--- a/tests/fixtures/rss/empty_feed.xml
+++ b/tests/fixtures/rss/empty_feed.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Empty Podcast</title>
+    <description>A podcast with no episodes yet</description>
+    <language>en-us</language>
+    <link>https://example.com/podcast</link>
+    <image>
+      <url>https://example.com/podcast.jpg</url>
+    </image>
+  </channel>
+</rss>

--- a/tests/fixtures/rss/multi_item.xml
+++ b/tests/fixtures/rss/multi_item.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Multi Episode Podcast</title>
+    <description>A podcast with multiple episodes</description>
+    <language>en-us</language>
+    <link>https://example.com/podcast</link>
+    <image>
+      <url>https://example.com/podcast.jpg</url>
+    </image>
+    <item>
+      <title>Episode One</title>
+      <guid>ep-001</guid>
+      <description>First episode</description>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/ep001.mp3" type="audio/mpeg" length="12345678"/>
+      <itunes:duration>25:30</itunes:duration>
+      <itunes:episode>1</itunes:episode>
+      <itunes:season>1</itunes:season>
+    </item>
+    <item>
+      <title>Episode Two</title>
+      <guid>ep-002</guid>
+      <description>Second episode</description>
+      <pubDate>Mon, 08 Jan 2024 12:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/ep002.mp3" type="audio/mpeg" length="23456789"/>
+      <itunes:duration>1:05:45</itunes:duration>
+      <itunes:episode>2</itunes:episode>
+      <itunes:season>1</itunes:season>
+    </item>
+    <item>
+      <title>Episode Three</title>
+      <guid>ep-003</guid>
+      <description>Third episode</description>
+      <pubDate>Mon, 15 Jan 2024 12:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/ep003.mp3" type="audio/mpeg" length="34567890"/>
+      <itunes:duration>45:00</itunes:duration>
+      <itunes:episode>3</itunes:episode>
+      <itunes:season>1</itunes:season>
+    </item>
+  </channel>
+</rss>

--- a/tests/fixtures/rss/single_item.xml
+++ b/tests/fixtures/rss/single_item.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Single Episode Podcast</title>
+    <description>A podcast with exactly one episode</description>
+    <language>en-us</language>
+    <link>https://example.com/podcast</link>
+    <image>
+      <url>https://example.com/podcast.jpg</url>
+    </image>
+    <item>
+      <title>The Only Episode</title>
+      <guid>ep-001</guid>
+      <description>This is the only episode in the feed</description>
+      <pubDate>Mon, 01 Jan 2024 12:00:00 GMT</pubDate>
+      <enclosure url="https://example.com/ep001.mp3" type="audio/mpeg" length="12345678"/>
+      <itunes:duration>30:00</itunes:duration>
+      <itunes:episode>1</itunes:episode>
+      <itunes:season>1</itunes:season>
+    </item>
+  </channel>
+</rss>

--- a/tests/unit/collection/__init__.py
+++ b/tests/unit/collection/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.

--- a/tests/unit/collection/test_feed_parsing.py
+++ b/tests/unit/collection/test_feed_parsing.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Regression tests for RSS feed parsing edge cases.
+
+These tests lock in the fix for single-item RSS parsing (dict vs list edge case).
+When an RSS feed contains exactly one <item>, xmltodict returns a dict instead
+of a list, which can break iteration if not handled properly.
+"""
+
+from pathlib import Path
+
+import pytest
+import xmltodict
+
+from voogle.collection import feed
+
+
+pytestmark = pytest.mark.unit
+
+FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures" / "rss"
+
+
+def _parse_feed_items(xml_content: str) -> list[dict]:
+    """Parse RSS XML and return items as a normalized list.
+
+    This helper mimics how read_episodes() should handle items,
+    ensuring dict-to-list normalization for single-item feeds.
+    """
+    parsed = xmltodict.parse(xml_content)
+    items = parsed["rss"]["channel"].get("item", [])
+
+    # Normalize: xmltodict returns dict for single item, list for multiple
+    if isinstance(items, dict):
+        items = [items]
+
+    return items
+
+
+class TestSingleItemRssParsing:
+    """Regression tests for single-item RSS feed parsing."""
+
+    @pytest.mark.description("Single-item RSS feed returns exactly one episode")
+    def test_single_item_feed_parses_successfully(self) -> None:
+        """When RSS has exactly one <item>, it should parse as a list of one."""
+        xml_content = (FIXTURES_DIR / "single_item.xml").read_text()
+        items = _parse_feed_items(xml_content)
+
+        assert isinstance(items, list), "Items must be a list, not dict"
+        assert len(items) == 1, "Should have exactly one episode"
+        assert items[0]["title"] == "The Only Episode"
+        assert items[0]["guid"] == "ep-001"
+
+    @pytest.mark.description("Multi-item RSS feed returns all episodes")
+    def test_multi_item_feed_parses_all_episodes(self) -> None:
+        """Standard case: multiple <item> elements parse as a list."""
+        xml_content = (FIXTURES_DIR / "multi_item.xml").read_text()
+        items = _parse_feed_items(xml_content)
+
+        assert isinstance(items, list), "Items must be a list"
+        assert len(items) == 3, "Should have three episodes"
+        assert items[0]["title"] == "Episode One"
+        assert items[1]["title"] == "Episode Two"
+        assert items[2]["title"] == "Episode Three"
+
+    @pytest.mark.description("Empty RSS feed returns empty list")
+    def test_empty_feed_returns_empty_list(self) -> None:
+        """When RSS has no <item> elements, return empty list gracefully."""
+        xml_content = (FIXTURES_DIR / "empty_feed.xml").read_text()
+        items = _parse_feed_items(xml_content)
+
+        assert isinstance(items, list), "Items must be a list"
+        assert len(items) == 0, "Should have zero episodes"
+
+
+class TestXmltodictBehavior:
+    """Document xmltodict's dict vs list behavior to catch future regressions."""
+
+    @pytest.mark.description("xmltodict returns dict for single item (raw behavior)")
+    def test_xmltodict_single_item_is_dict(self) -> None:
+        """Verify xmltodict's raw behavior that we're protecting against."""
+        xml_content = (FIXTURES_DIR / "single_item.xml").read_text()
+        parsed = xmltodict.parse(xml_content)
+        raw_items = parsed["rss"]["channel"]["item"]
+
+        # This is the bug: xmltodict returns a dict for single item
+        assert isinstance(raw_items, dict), (
+            "xmltodict should return dict for single item - "
+            "if this fails, xmltodict behavior changed"
+        )
+
+    @pytest.mark.description("xmltodict returns list for multiple items")
+    def test_xmltodict_multi_item_is_list(self) -> None:
+        """Verify xmltodict returns list when multiple items exist."""
+        xml_content = (FIXTURES_DIR / "multi_item.xml").read_text()
+        parsed = xmltodict.parse(xml_content)
+        raw_items = parsed["rss"]["channel"]["item"]
+
+        assert isinstance(raw_items, list), "xmltodict should return list for multiple items"
+
+
+class TestNormalizeItems:
+    """Tests for feed._normalize_items() function (the actual fix)."""
+
+    @pytest.mark.description("Single item dict is normalized to list")
+    def test_normalize_single_item_dict(self) -> None:
+        """When xmltodict returns a dict, normalize to list of one."""
+        channel_info = {"item": {"title": "Episode One", "guid": "ep-001"}}
+        result = feed._normalize_items(channel_info)
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["title"] == "Episode One"
+
+    @pytest.mark.description("Multiple items list is unchanged")
+    def test_normalize_multi_item_list(self) -> None:
+        """When xmltodict returns a list, keep it as-is."""
+        channel_info = {"item": [{"title": "Ep 1"}, {"title": "Ep 2"}]}
+        result = feed._normalize_items(channel_info)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    @pytest.mark.description("Missing items returns empty list")
+    def test_normalize_missing_items(self) -> None:
+        """When no items key exists, return empty list."""
+        channel_info = {"title": "Empty Channel"}
+        result = feed._normalize_items(channel_info)
+
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+
+class TestEpisodeDurationParsing:
+    """Tests for episode duration parsing edge cases."""
+
+    @pytest.mark.description("Duration in HH:MM:SS format parses correctly")
+    def test_duration_hhmmss(self) -> None:
+        """Duration like '1:05:45' should parse to seconds."""
+        assert feed._episode_duration("1:05:45") == 3945  # 1*3600 + 5*60 + 45
+
+    @pytest.mark.description("Duration in MM:SS format parses correctly")
+    def test_duration_mmss(self) -> None:
+        """Duration like '30:00' should parse to seconds."""
+        assert feed._episode_duration("30:00") == 1800  # 30*60 + 0
+
+    @pytest.mark.description("Duration as integer seconds parses correctly")
+    def test_duration_integer(self) -> None:
+        """Duration like '1800' (raw seconds) should parse."""
+        assert feed._episode_duration("1800") == 1800
+
+    @pytest.mark.description("None duration returns -1")
+    def test_duration_none(self) -> None:
+        """Missing duration should return -1."""
+        assert feed._episode_duration(None) == -1
+
+
+class TestEpisodeGuidParsing:
+    """Tests for episode GUID parsing edge cases."""
+
+    @pytest.mark.description("String GUID returns as-is")
+    def test_guid_string(self) -> None:
+        """Simple string GUID should return unchanged."""
+        assert feed._episode_guid("ep-001") == "ep-001"
+
+    @pytest.mark.description("Dict GUID extracts #text value")
+    def test_guid_dict(self) -> None:
+        """GUID as dict with #text should extract the text."""
+        assert feed._episode_guid({"#text": "ep-002", "@isPermaLink": "false"}) == "ep-002"


### PR DESCRIPTION
## Summary
- Fix single-item RSS parsing bug where xmltodict returns dict instead of list
- Add `_normalize_items()` helper function to `feed.py`
- Add 14 regression tests covering edge cases
- Add RSS fixture files (single, multi, empty) for deterministic testing

## Changes
- `backend/src/voogle/collection/feed.py`: Add `_normalize_items()` helper
- `tests/unit/collection/test_feed_parsing.py`: 14 new unit tests
- `tests/fixtures/rss/`: 3 RSS fixture files
- `CHANGELOG.md`: Document the fix

## Test plan
- [x] All 14 new regression tests pass
- [x] Unit tests pass (72 passed, excluding pre-existing failures)
- [x] E2E tests pass (5 passed)
- [x] Ruff lint passes

## Pre-existing test issues (not introduced by this PR)
- `test_query_returns_local_url_for_local_channel`: Missing fixture file
- `test_calculate_fragments*`: Component test infrastructure

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)