### PR TITLE
feat: add URL health checking and refresh capability (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Format: **WHAT** changed, **WHY** it changed, and any **REASONING** behind decis
 ## [Unreleased]
 
 ### Added
+- **Refresh episode URL capability** (#24)
+  - New `backend/src/voogle/collection/url_health.py` module for URL validation and refresh
+  - `check_url()`: HEAD request with timeout and comprehensive error handling
+  - `check_episode_url()`, `check_channel_urls()`, `check_all_broken_urls()`: Batch URL checking
+  - `find_episode_in_rss()`: Match episodes by GUID (preferred) or title (fallback)
+  - `find_updated_url()`, `preview_channel_refresh()`, `apply_url_refresh()`: URL refresh workflow
+  - Streamlit admin UI in Media page with 3 sections:
+    - "Detect Broken URLs": Scan all episodes and show broken ones
+    - "Preview URL Refresh": Show old/new URLs before applying
+    - "Apply URL Refresh": Update URLs with confirmation
+  - Rate limiting (0.5s delay between requests) to avoid CDN rate limits
+  - Audit logging of URL changes (old URL, new URL) for rollback capability
+  - Preserves transcription and embeddings status during URL refresh
+
+**WHY**: Podcast hosts sometimes change CDNs or file locations, causing episode URLs to 404. Previously this required deleting the episode and losing transcription/embedding work. Now admins can detect and fix broken URLs while preserving all processing work.
+
+**REASONING**: Safe by default - all changes require explicit admin action with preview. HEAD requests minimize bandwidth. GUID-first matching is stable; title fallback handles GUID changes. No automatic refresh to prevent unintended changes.
+
 - **Configurable chunking strategy per channel** (#19)
   - New `ChunkingConfig` dataclass with `chunk_size_words`, `chunk_overlap_words`, `min_chunk_length_words`
   - YAML config file at `config/chunking.yaml` for per-channel settings

--- a/backend/src/voogle/collection/__init__.py
+++ b/backend/src/voogle/collection/__init__.py
@@ -23,3 +23,13 @@ from .feed import read_channel as read_channel
 from .feed import read_episodes as read_episodes
 from .local import read_local_channel as read_local_channel
 from .local import read_local_episodes as read_local_episodes
+from .url_health import URLHealthResult as URLHealthResult
+from .url_health import URLRefreshResult as URLRefreshResult
+from .url_health import URLStatus as URLStatus
+from .url_health import apply_url_refresh as apply_url_refresh
+from .url_health import check_all_broken_urls as check_all_broken_urls
+from .url_health import check_channel_urls as check_channel_urls
+from .url_health import check_episode_url as check_episode_url
+from .url_health import check_url as check_url
+from .url_health import preview_channel_refresh as preview_channel_refresh
+from .url_health import refresh_broken_urls as refresh_broken_urls

--- a/backend/src/voogle/collection/url_health.py
+++ b/backend/src/voogle/collection/url_health.py
@@ -1,0 +1,454 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""URL health checking and refresh utilities.
+
+Provides functions to detect broken episode media URLs and refresh them
+from updated RSS feeds without losing transcription or embedding work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Callable
+
+import requests
+from requests.exceptions import ConnectionError, RequestException, Timeout
+
+from voogle import models
+from voogle.collection import feed
+
+logger = logging.getLogger(__name__)
+
+# Constants
+HEAD_TIMEOUT = 10  # seconds for HEAD requests
+GET_TIMEOUT = 30  # seconds for full feed fetch
+BATCH_DELAY = 0.5  # seconds between requests to avoid rate limiting
+
+
+class URLStatus(Enum):
+    """Status codes for URL health checks."""
+
+    OK = "ok"  # URL responds 200
+    NOT_FOUND = "not_found"  # 404
+    FORBIDDEN = "forbidden"  # 403
+    SERVER_ERROR = "server_error"  # 5xx
+    TIMEOUT = "timeout"  # Request timed out
+    CONNECTION_ERROR = "connection_error"  # Host unreachable
+    REDIRECT_LOOP = "redirect_loop"  # Too many redirects
+    INVALID_URL = "invalid_url"  # Malformed URL
+
+
+@dataclass
+class URLHealthResult:
+    """Result of checking a single episode URL."""
+
+    episode_pk: int
+    episode_title: str
+    url: str
+    status: URLStatus
+    http_code: int | None  # Actual HTTP status code if available
+    error_message: str | None  # Human-readable error
+    checked_at: datetime
+
+
+@dataclass
+class URLRefreshResult:
+    """Result of attempting to find an updated URL for an episode."""
+
+    episode_pk: int
+    episode_title: str
+    old_url: str
+    new_url: str | None  # None if no match found in RSS
+    match_method: str | None  # "guid" or "title"
+    new_url_valid: bool  # True if new URL responds 200
+    error_message: str | None  # Why refresh failed (if applicable)
+
+
+def check_url(url: str, timeout: int = HEAD_TIMEOUT) -> tuple[URLStatus, int | None, str | None]:
+    """Check URL health via HEAD request.
+
+    Args:
+        url: URL to check
+        timeout: Request timeout in seconds
+
+    Returns:
+        Tuple of (status, http_code, error_message)
+    """
+    try:
+        response = requests.head(
+            url,
+            timeout=timeout,
+            allow_redirects=True,
+            headers={"User-Agent": "Voogle/1.0 (URL Health Check)"},
+        )
+        response.raise_for_status()
+        return URLStatus.OK, response.status_code, None
+
+    except Timeout:
+        return URLStatus.TIMEOUT, None, "Request timed out"
+    except ConnectionError:
+        return URLStatus.CONNECTION_ERROR, None, "Host unreachable"
+    except requests.exceptions.TooManyRedirects:
+        return URLStatus.REDIRECT_LOOP, None, "Too many redirects"
+    except requests.HTTPError as e:
+        code = e.response.status_code if e.response is not None else None
+        if code == 404:
+            return URLStatus.NOT_FOUND, code, "URL not found"
+        elif code == 403:
+            return URLStatus.FORBIDDEN, code, "Access forbidden"
+        elif code is not None and 500 <= code < 600:
+            return URLStatus.SERVER_ERROR, code, f"Server error ({code})"
+        else:
+            return URLStatus.SERVER_ERROR, code, f"HTTP error ({code})"
+    except RequestException as e:
+        return URLStatus.INVALID_URL, None, str(e)
+
+
+async def check_episode_url(episode: models.Episode) -> URLHealthResult:
+    """Check the health of an episode's media URL.
+
+    Args:
+        episode: Episode to check
+
+    Returns:
+        URLHealthResult with status and error details
+    """
+    status, http_code, error_message = check_url(str(episode.url))
+    return URLHealthResult(
+        episode_pk=episode.pk,
+        episode_title=str(episode.title),
+        url=str(episode.url),
+        status=status,
+        http_code=http_code,
+        error_message=error_message,
+        checked_at=datetime.now(timezone.utc),
+    )
+
+
+async def check_channel_urls(
+    channel: models.Channel,
+    on_progress: Callable[[int, int], None] | None = None,
+) -> list[URLHealthResult]:
+    """Check all episode URLs for a channel with rate limiting.
+
+    Args:
+        channel: Channel to check
+        on_progress: Callback(checked_count, total_count) for progress
+
+    Returns:
+        List of URLHealthResult for all episodes
+    """
+    episodes = await models.Episode.objects.filter(channel=channel).all()
+    total = len(episodes)
+    results: list[URLHealthResult] = []
+
+    for i, episode in enumerate(episodes):
+        result = await check_episode_url(episode)
+        results.append(result)
+
+        if on_progress:
+            on_progress(i + 1, total)
+
+        # Rate limiting
+        if i < total - 1:
+            await asyncio.sleep(BATCH_DELAY)
+
+    return results
+
+
+async def check_all_broken_urls(
+    on_progress: Callable[[int, int], None] | None = None,
+) -> list[URLHealthResult]:
+    """Check all episode URLs across all channels.
+
+    Args:
+        on_progress: Callback(checked_count, total_count) for progress
+
+    Returns:
+        List of URLHealthResult for episodes with non-OK status only
+    """
+    episodes = await models.Episode.objects.all()
+    total = len(episodes)
+    broken: list[URLHealthResult] = []
+
+    for i, episode in enumerate(episodes):
+        result = await check_episode_url(episode)
+        if result.status != URLStatus.OK:
+            broken.append(result)
+
+        if on_progress:
+            on_progress(i + 1, total)
+
+        # Rate limiting
+        if i < total - 1:
+            await asyncio.sleep(BATCH_DELAY)
+
+    return broken
+
+
+def find_episode_in_rss(
+    episode: models.Episode,
+    rss_items: list[dict],
+) -> tuple[dict | None, str | None]:
+    """Match an episode to an RSS item by GUID (preferred) or title (fallback).
+
+    Args:
+        episode: Episode to match
+        rss_items: List of RSS item dicts from parsed feed
+
+    Returns:
+        Tuple of (matching_item, match_method) where match_method is "guid" or "title"
+    """
+    episode_guid = str(episode.guid)
+    episode_title = str(episode.title).lower().strip()
+
+    # First pass: match by GUID
+    for item in rss_items:
+        item_guid = feed._episode_guid(item.get("guid", ""))
+        if item_guid == episode_guid:
+            return item, "guid"
+
+    # Second pass: match by title (fallback)
+    for item in rss_items:
+        item_title = (item.get("title") or "").lower().strip()
+        if item_title == episode_title:
+            logger.warning(f"Episode {episode.pk} matched by title, not GUID")
+            return item, "title"
+
+    return None, None
+
+
+async def find_updated_url(
+    episode: models.Episode,
+    channel: models.Channel,
+) -> URLRefreshResult:
+    """Re-fetch channel RSS and find updated URL for episode.
+
+    Strategy:
+    1. Fetch current RSS feed for channel
+    2. Match episode by GUID (preferred) or title (fallback)
+    3. Compare enclosure URL to stored URL
+    4. If different, validate new URL responds 200
+    5. Return result with old URL, new URL, and validation status
+
+    Args:
+        episode: Episode to find updated URL for
+        channel: Channel containing the episode
+
+    Returns:
+        URLRefreshResult with old/new URLs and validation status
+    """
+    old_url = str(episode.url)
+
+    # Fetch current RSS feed
+    feed_data = feed._read_channel_feed(str(channel.feed))
+    if feed_data is None:
+        return URLRefreshResult(
+            episode_pk=episode.pk,
+            episode_title=str(episode.title),
+            old_url=old_url,
+            new_url=None,
+            match_method=None,
+            new_url_valid=False,
+            error_message="Failed to fetch RSS feed",
+        )
+
+    # Get RSS items
+    try:
+        rss_items = feed_data["rss"]["channel"]["item"]
+        # Handle single item case (xmltodict returns dict instead of list)
+        if isinstance(rss_items, dict):
+            rss_items = [rss_items]
+    except (KeyError, TypeError):
+        return URLRefreshResult(
+            episode_pk=episode.pk,
+            episode_title=str(episode.title),
+            old_url=old_url,
+            new_url=None,
+            match_method=None,
+            new_url_valid=False,
+            error_message="Invalid RSS feed structure",
+        )
+
+    # Find matching item
+    matching_item, match_method = find_episode_in_rss(episode, rss_items)
+    if matching_item is None:
+        return URLRefreshResult(
+            episode_pk=episode.pk,
+            episode_title=str(episode.title),
+            old_url=old_url,
+            new_url=None,
+            match_method=None,
+            new_url_valid=False,
+            error_message="Episode not found in current RSS feed",
+        )
+
+    # Extract new URL
+    try:
+        new_url = matching_item["enclosure"]["@url"]
+    except (KeyError, TypeError):
+        return URLRefreshResult(
+            episode_pk=episode.pk,
+            episode_title=str(episode.title),
+            old_url=old_url,
+            new_url=None,
+            match_method=match_method,
+            new_url_valid=False,
+            error_message="No enclosure URL in RSS item",
+        )
+
+    # Check if URL changed
+    if new_url == old_url:
+        return URLRefreshResult(
+            episode_pk=episode.pk,
+            episode_title=str(episode.title),
+            old_url=old_url,
+            new_url=new_url,
+            match_method=match_method,
+            new_url_valid=True,
+            error_message="URL unchanged",
+        )
+
+    # Validate new URL
+    status, _, error = check_url(new_url)
+    new_url_valid = status == URLStatus.OK
+
+    return URLRefreshResult(
+        episode_pk=episode.pk,
+        episode_title=str(episode.title),
+        old_url=old_url,
+        new_url=new_url,
+        match_method=match_method,
+        new_url_valid=new_url_valid,
+        error_message=None if new_url_valid else f"New URL not accessible: {error}",
+    )
+
+
+async def preview_channel_refresh(
+    channel: models.Channel,
+    broken_only: bool = True,
+) -> list[URLRefreshResult]:
+    """Preview URL refreshes for a channel without applying changes.
+
+    Args:
+        channel: Channel to check
+        broken_only: If True, only check episodes with broken URLs
+
+    Returns:
+        List of URLRefreshResult showing potential changes
+    """
+    episodes = await models.Episode.objects.filter(channel=channel).all()
+    results: list[URLRefreshResult] = []
+
+    for episode in episodes:
+        if broken_only:
+            # Check if URL is broken first
+            health = await check_episode_url(episode)
+            if health.status == URLStatus.OK:
+                continue
+            await asyncio.sleep(BATCH_DELAY)
+
+        # Find updated URL
+        result = await find_updated_url(episode, channel)
+
+        # Only include if URL actually changed and is different
+        if result.new_url and result.new_url != result.old_url:
+            results.append(result)
+
+        await asyncio.sleep(BATCH_DELAY)
+
+    return results
+
+
+async def apply_url_refresh(
+    episode: models.Episode,
+    new_url: str,
+) -> None:
+    """Apply a URL refresh to an episode.
+
+    - Validates new URL responds 200 before updating
+    - Logs old URL for audit trail
+    - Updates episode.url in database
+    - Preserves transcription and embeddings status
+
+    Args:
+        episode: Episode to update
+        new_url: New URL to set
+
+    Raises:
+        ValueError: If new URL is not accessible
+    """
+    old_url = str(episode.url)
+
+    # Validate new URL is accessible
+    status, _code, error = check_url(new_url)
+    if status != URLStatus.OK:
+        raise ValueError(f"New URL not accessible: {error}")
+
+    # Log for audit trail
+    logger.info(
+        "Refreshing episode URL",
+        extra={
+            "episode_pk": episode.pk,
+            "episode_title": str(episode.title),
+            "old_url": old_url,
+            "new_url": new_url,
+        },
+    )
+
+    # Update database (preserves transcription/embeddings)
+    await episode.update(url=new_url)
+
+
+async def refresh_broken_urls(
+    channel: models.Channel,
+    dry_run: bool = True,
+) -> list[URLRefreshResult]:
+    """Refresh all broken URLs for a channel from its RSS feed.
+
+    Args:
+        channel: Channel to refresh
+        dry_run: If True, preview only (don't apply changes)
+
+    Returns:
+        List of URLRefreshResult for all broken episodes
+    """
+    # Get preview of changes
+    results = await preview_channel_refresh(channel, broken_only=True)
+
+    if dry_run:
+        return results
+
+    # Apply changes for valid new URLs
+    applied_results: list[URLRefreshResult] = []
+    for result in results:
+        if result.new_url and result.new_url_valid:
+            try:
+                episode = await models.Episode.objects.get(pk=result.episode_pk)
+                await apply_url_refresh(episode, result.new_url)
+                applied_results.append(result)
+            except Exception as e:
+                logger.error(
+                    f"Failed to apply URL refresh for episode {result.episode_pk}: {e}"
+                )
+                # Update result with error
+                applied_results.append(
+                    URLRefreshResult(
+                        episode_pk=result.episode_pk,
+                        episode_title=result.episode_title,
+                        old_url=result.old_url,
+                        new_url=result.new_url,
+                        match_method=result.match_method,
+                        new_url_valid=False,
+                        error_message=f"Failed to apply: {e}",
+                    )
+                )
+        else:
+            applied_results.append(result)
+
+    return applied_results

--- a/backend/src/voogle/management/pages/3_🔈-Media.py
+++ b/backend/src/voogle/management/pages/3_🔈-Media.py
@@ -7,6 +7,7 @@ import asyncio
 import streamlit as st
 
 from voogle import collection, models, routers, settings, tasks
+from voogle.collection import url_health
 from voogle.management import utils as m_utils
 
 
@@ -99,6 +100,142 @@ async def podcasts_and_episodes() -> None:
                 st.markdown(ch.description)
 
 
+async def url_health_section() -> None:
+    st.header("URL Health")
+    st.markdown(
+        """Detect and fix broken episode media URLs.
+        This helps recover episodes when podcast hosts change their CDN or file locations."""
+    )
+
+    # Metrics
+    col1, _col2 = st.columns(2)
+    total_episodes = await models.Episode.objects.count()
+    col1.metric("Total Episodes", total_episodes)
+
+    # Initialize session state for results
+    if "broken_urls" not in st.session_state:
+        st.session_state.broken_urls = None
+    if "refresh_preview" not in st.session_state:
+        st.session_state.refresh_preview = None
+
+    # Section 1: Detect broken URLs
+    st.subheader("1. Detect Broken URLs")
+    st.info("This will check all episode URLs via HEAD requests. May take several minutes.")
+
+    if st.button("Scan All Episode URLs", use_container_width=True):
+        progress_bar = st.progress(0, text="Checking URLs...")
+
+        def update_progress(checked: int, total: int) -> None:
+            progress_bar.progress(checked / total, text=f"Checking URL {checked}/{total}...")
+
+        with st.spinner("Checking URLs... This may take several minutes."):
+            broken = await url_health.check_all_broken_urls(on_progress=update_progress)
+            st.session_state.broken_urls = broken
+
+        progress_bar.empty()
+
+        if not broken:
+            st.success("All episode URLs are accessible!")
+        else:
+            st.warning(f"Found {len(broken)} broken URLs")
+
+    # Display broken URLs if we have results
+    if st.session_state.broken_urls:
+        broken = st.session_state.broken_urls
+        st.markdown(f"**{len(broken)} broken URLs found:**")
+        for result in broken:
+            with st.expander(f"{result.episode_title}"):
+                st.code(result.url)
+                st.error(f"Status: {result.status.value} - {result.error_message}")
+
+    st.divider()
+
+    # Section 2: Preview URL refresh
+    st.subheader("2. Preview URL Refresh")
+    st.markdown("Select a channel to check for updated URLs in its RSS feed.")
+
+    channels = await models.Channel.objects.filter(
+        kind=models.ChannelKind.podcast.value
+    ).all()
+
+    if not channels:
+        st.info("No podcast channels found. Add a channel first.")
+    else:
+        channel_options = {ch.title: ch for ch in channels}
+        selected_channel_name = st.selectbox(
+            "Select channel to preview",
+            options=list(channel_options.keys()),
+            key="preview_channel_select",
+        )
+
+        col1, _col2 = st.columns(2)
+        with col1:
+            broken_only = st.checkbox("Check broken URLs only", value=True)
+
+        if st.button("Preview Changes", use_container_width=True):
+            channel = channel_options[selected_channel_name]
+            with st.spinner("Fetching RSS and comparing URLs..."):
+                results = await url_health.preview_channel_refresh(
+                    channel, broken_only=broken_only
+                )
+                st.session_state.refresh_preview = results
+
+            if not results:
+                st.success("No URL changes found")
+            else:
+                st.info(f"Found {len(results)} potential URL updates")
+
+        # Display preview results
+        if st.session_state.refresh_preview:
+            results = st.session_state.refresh_preview
+            for result in results:
+                with st.expander(f"{result.episode_title}"):
+                    st.markdown(f"**Old URL:** `{result.old_url}`")
+                    st.markdown(f"**New URL:** `{result.new_url}`")
+                    st.markdown(f"**Match method:** {result.match_method}")
+                    if result.new_url_valid:
+                        st.success("New URL is accessible")
+                    else:
+                        st.error(f"New URL not accessible: {result.error_message}")
+
+    st.divider()
+
+    # Section 3: Apply URL refresh
+    st.subheader("3. Apply URL Refresh")
+    st.warning("This will update episode URLs in the database. Preview first!")
+
+    if channels:
+        selected_apply_channel_name = st.selectbox(
+            "Select channel to refresh",
+            options=list(channel_options.keys()),
+            key="apply_channel_select",
+        )
+
+        if st.button("Apply Refresh for Selected Channel", use_container_width=True):
+            channel = channel_options[selected_apply_channel_name]
+            with st.spinner("Applying URL refreshes..."):
+                results = await url_health.refresh_broken_urls(channel, dry_run=False)
+
+            applied = [r for r in results if r.new_url and r.new_url_valid]
+            failed = [r for r in results if r.error_message and not r.new_url_valid]
+
+            if applied:
+                st.success(f"Updated {len(applied)} episode URLs")
+                for r in applied:
+                    st.markdown(f"- **{r.episode_title}**: URL updated")
+
+            if failed:
+                st.error(f"Failed to update {len(failed)} episodes")
+                for r in failed:
+                    st.markdown(f"- **{r.episode_title}**: {r.error_message}")
+
+            if not applied and not failed:
+                st.info("No URLs needed updating")
+
+            # Clear preview cache after applying
+            st.session_state.refresh_preview = None
+
+
 async def main() -> None:
     st.set_page_config(page_title="Voogle", page_icon="🎧")
     st.title("📻 Media")
@@ -108,6 +245,8 @@ async def main() -> None:
         await add_local_channel()
         st.divider()
         await podcasts_and_episodes()
+        st.divider()
+        await url_health_section()
 
 
 if __name__ == "__main__":

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -4,7 +4,639 @@ Active tasks and implementation plans for Voogle.
 
 ---
 
-## Active: YouTube Playlist Ingestion Adapter (Milestone C)
+## Active: Refresh Episode URL Capability (Issue #24)
+
+**Goal**: Add capability to refresh episode URLs when enclosure URLs return 404, recovering without deleting the episode or losing transcription/embedding work.
+
+**Status**: Planning
+
+**Branch**: `feat/24-refresh-episode-urls`
+
+**Issue**: https://github.com/jbraseth/voogle/issues/24
+
+---
+
+### Architecture Overview
+
+This feature adds a new module `backend/src/voogle/collection/url_health.py` for URL validation and refresh logic, plus Streamlit admin controls for detecting and fixing broken URLs.
+
+**Data Flow**:
+```
+Admin triggers "Detect Broken URLs"
+    ↓
+url_health.check_episode_url(episode) → HEAD request
+    ↓
+Returns URLHealthResult(status, error_code, error_message)
+    ↓
+Admin sees list of broken episodes with error details
+    ↓
+Admin clicks "Preview Refresh" for a channel
+    ↓
+url_health.find_updated_url(episode, channel) → re-fetch RSS, match by GUID
+    ↓
+Returns URLRefreshResult(old_url, new_url, validation_status)
+    ↓
+Admin confirms refresh
+    ↓
+url_health.apply_url_refresh(episode, new_url) → updates DB, logs change
+```
+
+---
+
+### Data Types
+
+```python
+# backend/src/voogle/collection/url_health.py
+
+from dataclasses import dataclass
+from enum import Enum
+from datetime import datetime
+
+class URLStatus(Enum):
+    OK = "ok"                      # URL responds 200
+    NOT_FOUND = "not_found"        # 404
+    FORBIDDEN = "forbidden"        # 403
+    SERVER_ERROR = "server_error"  # 5xx
+    TIMEOUT = "timeout"            # Request timed out
+    CONNECTION_ERROR = "connection_error"  # Host unreachable
+    REDIRECT_LOOP = "redirect_loop"  # Too many redirects
+    INVALID_URL = "invalid_url"    # Malformed URL
+
+@dataclass
+class URLHealthResult:
+    """Result of checking a single episode URL."""
+    episode_pk: int
+    episode_title: str
+    url: str
+    status: URLStatus
+    http_code: int | None          # Actual HTTP status code if available
+    error_message: str | None      # Human-readable error
+    checked_at: datetime
+
+@dataclass
+class URLRefreshResult:
+    """Result of attempting to find an updated URL for an episode."""
+    episode_pk: int
+    episode_title: str
+    old_url: str
+    new_url: str | None            # None if no match found in RSS
+    match_method: str | None       # "guid" or "title"
+    new_url_valid: bool            # True if new URL responds 200
+    error_message: str | None      # Why refresh failed (if applicable)
+```
+
+---
+
+### Module Interface
+
+```python
+# backend/src/voogle/collection/url_health.py
+
+import logging
+from typing import AsyncIterator
+import requests
+from requests.exceptions import Timeout, ConnectionError, RequestException
+
+from voogle import models
+from voogle.collection import feed
+
+logger = logging.getLogger(__name__)
+
+# Constants
+HEAD_TIMEOUT = 10  # seconds
+GET_TIMEOUT = 30   # seconds for full feed fetch
+BATCH_DELAY = 0.5  # seconds between requests to avoid rate limiting
+
+
+def check_url(url: str, timeout: int = HEAD_TIMEOUT) -> URLHealthResult:
+    """Check if a URL is accessible via HEAD request.
+
+    Returns URLHealthResult with status and error details.
+    Does not raise exceptions - all errors captured in result.
+    """
+
+
+async def check_episode_url(episode: models.Episode) -> URLHealthResult:
+    """Check the health of an episode's media URL."""
+
+
+async def check_channel_urls(
+    channel: models.Channel,
+    on_progress: Callable[[int, int], None] | None = None
+) -> list[URLHealthResult]:
+    """Check all episode URLs for a channel with rate limiting.
+
+    Args:
+        channel: Channel to check
+        on_progress: Callback(checked_count, total_count) for progress
+
+    Returns list of URLHealthResult for all episodes.
+    """
+
+
+async def check_all_broken_urls(
+    on_progress: Callable[[int, int], None] | None = None
+) -> list[URLHealthResult]:
+    """Check all episode URLs across all channels.
+
+    Returns only episodes with non-OK status.
+    """
+
+
+def find_episode_in_rss(
+    episode: models.Episode,
+    rss_items: list[dict]
+) -> dict | None:
+    """Match an episode to an RSS item by GUID (preferred) or title (fallback).
+
+    Returns the matching RSS item dict or None if not found.
+    """
+
+
+async def find_updated_url(
+    episode: models.Episode,
+    channel: models.Channel
+) -> URLRefreshResult:
+    """Re-fetch channel RSS and find updated URL for episode.
+
+    Strategy:
+    1. Fetch current RSS feed for channel
+    2. Match episode by GUID (preferred) or title (fallback)
+    3. Compare enclosure URL to stored URL
+    4. If different, validate new URL responds 200
+    5. Return result with old URL, new URL, and validation status
+    """
+
+
+async def preview_channel_refresh(
+    channel: models.Channel,
+    broken_only: bool = True
+) -> list[URLRefreshResult]:
+    """Preview URL refreshes for a channel without applying changes.
+
+    Args:
+        channel: Channel to check
+        broken_only: If True, only check episodes with broken URLs
+
+    Returns list of URLRefreshResult showing potential changes.
+    """
+
+
+async def apply_url_refresh(
+    episode: models.Episode,
+    new_url: str
+) -> None:
+    """Apply a URL refresh to an episode.
+
+    - Validates new URL responds 200 before updating
+    - Logs old URL for audit trail
+    - Updates episode.url in database
+    - Preserves transcription and embeddings status
+
+    Raises ValueError if new URL is not accessible.
+    """
+
+
+async def refresh_broken_urls(
+    channel: models.Channel,
+    dry_run: bool = True
+) -> list[URLRefreshResult]:
+    """Refresh all broken URLs for a channel from its RSS feed.
+
+    Args:
+        channel: Channel to refresh
+        dry_run: If True, preview only (don't apply changes)
+
+    Returns list of URLRefreshResult for all broken episodes.
+    """
+```
+
+---
+
+### Implementation Steps
+
+#### Step 1: Create url_health.py module
+
+Create `backend/src/voogle/collection/url_health.py` with:
+- Data classes (URLStatus, URLHealthResult, URLRefreshResult)
+- `check_url()` - basic HEAD request with timeout and error handling
+- `check_episode_url()` - wrapper for Episode model
+
+**Key implementation detail for check_url()**:
+```python
+def check_url(url: str, timeout: int = HEAD_TIMEOUT) -> tuple[URLStatus, int | None, str | None]:
+    """Check URL health via HEAD request."""
+    try:
+        response = requests.head(
+            url,
+            timeout=timeout,
+            allow_redirects=True,
+            headers={"User-Agent": "Voogle/1.0 (URL Health Check)"}
+        )
+        response.raise_for_status()
+        return URLStatus.OK, response.status_code, None
+
+    except Timeout:
+        return URLStatus.TIMEOUT, None, "Request timed out"
+    except ConnectionError:
+        return URLStatus.CONNECTION_ERROR, None, "Host unreachable"
+    except requests.HTTPError as e:
+        code = e.response.status_code
+        if code == 404:
+            return URLStatus.NOT_FOUND, code, "URL not found"
+        elif code == 403:
+            return URLStatus.FORBIDDEN, code, "Access forbidden"
+        elif 500 <= code < 600:
+            return URLStatus.SERVER_ERROR, code, f"Server error ({code})"
+        else:
+            return URLStatus.SERVER_ERROR, code, f"HTTP error ({code})"
+    except RequestException as e:
+        return URLStatus.INVALID_URL, None, str(e)
+```
+
+#### Step 2: Implement batch URL checking
+
+Add `check_channel_urls()` and `check_all_broken_urls()` with:
+- Rate limiting (0.5s delay between requests)
+- Progress callback for UI updates
+- Parallel checking within channel, sequential between channels
+
+#### Step 3: Implement RSS re-parsing for URL refresh
+
+Add `find_episode_in_rss()` with episode matching logic:
+```python
+def find_episode_in_rss(
+    episode: models.Episode,
+    rss_items: list[dict]
+) -> dict | None:
+    """Match episode to RSS item by GUID (preferred) or title (fallback)."""
+    episode_guid = str(episode.guid)
+    episode_title = str(episode.title).lower().strip()
+
+    # First pass: match by GUID
+    for item in rss_items:
+        item_guid = feed._episode_guid(item.get("guid", ""))
+        if item_guid == episode_guid:
+            return item
+
+    # Second pass: match by title (fallback)
+    for item in rss_items:
+        item_title = (item.get("title") or "").lower().strip()
+        if item_title == episode_title:
+            logger.warning(f"Episode {episode.pk} matched by title, not GUID")
+            return item
+
+    return None
+```
+
+#### Step 4: Implement URL refresh functions
+
+Add `find_updated_url()`, `preview_channel_refresh()`, and `apply_url_refresh()`:
+- `find_updated_url()` - fetch RSS, match, compare URLs, validate new URL
+- `preview_channel_refresh()` - batch preview without DB changes
+- `apply_url_refresh()` - validate and persist URL change
+
+**Key: apply_url_refresh() audit logging**:
+```python
+async def apply_url_refresh(episode: models.Episode, new_url: str) -> None:
+    """Apply URL refresh with validation and audit logging."""
+    old_url = episode.url
+
+    # Validate new URL is accessible
+    status, code, error = check_url(new_url)
+    if status != URLStatus.OK:
+        raise ValueError(f"New URL not accessible: {error}")
+
+    # Log for audit trail
+    logger.info(
+        f"Refreshing episode URL",
+        extra={
+            "episode_pk": episode.pk,
+            "episode_title": episode.title,
+            "old_url": old_url,
+            "new_url": new_url,
+        }
+    )
+
+    # Update database (preserves transcription/embeddings)
+    await episode.update(url=new_url)
+```
+
+#### Step 5: Add Streamlit admin controls
+
+Create new section in `backend/src/voogle/management/pages/3_🔈-Media.py`:
+
+```python
+async def url_health_section() -> None:
+    st.header("🔗 URL Health")
+    st.markdown("""Detect and fix broken episode media URLs.
+    This helps recover episodes when podcast hosts change their CDN or file locations.""")
+
+    # Metrics
+    col1, col2 = st.columns(2)
+    total_episodes = await models.Episode.objects.count()
+    col1.metric("Total Episodes", total_episodes)
+
+    # Last check status
+    if last_check := utils.get_event("event_url_check_start"):
+        last_time = datetime.fromtimestamp(float(last_check["time"]), tz=timezone.utc)
+        col2.markdown(f"**Last check**: `{last_time.strftime('%c')}`")
+
+    # Detect broken URLs button
+    st.subheader("1. Detect Broken URLs")
+    if st.button("🔍 Scan All Episode URLs", use_container_width=True):
+        with st.spinner("⌛ Checking URLs... This may take several minutes."):
+            broken = await url_health.check_all_broken_urls()
+
+        if not broken:
+            st.success("✓ All episode URLs are accessible!")
+        else:
+            st.warning(f"Found {len(broken)} broken URLs")
+            for result in broken:
+                with st.expander(f"❌ {result.episode_title}"):
+                    st.code(result.url)
+                    st.error(f"Status: {result.status.value} - {result.error_message}")
+
+    st.divider()
+
+    # Preview refresh section
+    st.subheader("2. Preview URL Refresh")
+    channels = await models.Channel.objects.all()
+    channel_options = {ch.title: ch for ch in channels}
+
+    selected_channel = st.selectbox(
+        "Select channel to preview",
+        options=list(channel_options.keys())
+    )
+
+    if st.button("👁️ Preview Changes", use_container_width=True):
+        channel = channel_options[selected_channel]
+        with st.spinner("⌛ Fetching RSS and comparing URLs..."):
+            results = await url_health.preview_channel_refresh(channel, broken_only=True)
+
+        if not results:
+            st.success("✓ No URL changes found")
+        else:
+            st.info(f"Found {len(results)} potential URL updates")
+            for result in results:
+                with st.expander(f"📝 {result.episode_title}"):
+                    st.markdown(f"**Old URL**: `{result.old_url}`")
+                    st.markdown(f"**New URL**: `{result.new_url}`")
+                    st.markdown(f"**Match method**: {result.match_method}")
+                    if result.new_url_valid:
+                        st.success("✓ New URL is accessible")
+                    else:
+                        st.error(f"❌ New URL not accessible: {result.error_message}")
+
+    st.divider()
+
+    # Apply refresh section
+    st.subheader("3. Apply URL Refresh")
+    st.warning("⚠️ This will update episode URLs in the database. Preview first!")
+
+    if st.button("🔄 Apply Refresh for Selected Channel", use_container_width=True):
+        channel = channel_options[selected_channel]
+        with st.spinner("⌛ Applying URL refreshes..."):
+            results = await url_health.refresh_broken_urls(channel, dry_run=False)
+
+        applied = [r for r in results if r.new_url and r.new_url_valid]
+        failed = [r for r in results if r.error_message]
+
+        if applied:
+            st.success(f"✓ Updated {len(applied)} episode URLs")
+        if failed:
+            st.error(f"❌ Failed to update {len(failed)} episodes")
+            for result in failed:
+                st.error(f"- {result.episode_title}: {result.error_message}")
+```
+
+#### Step 6: Add event logging for URL health checks
+
+Add to `utils.py`:
+- `"event_url_check_start"` - when URL scan begins
+- `"event_url_check_end"` - when URL scan completes with summary
+
+#### Step 7: Add tests
+
+Create `tests/unit/collection/test_url_health.py`:
+```python
+pytestmark = pytest.mark.unit
+
+class TestCheckUrl:
+    @pytest.mark.description("check_url returns OK for accessible URLs")
+    def test_accessible_url(self) -> None:
+        with patch("requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_head.return_value = mock_response
+
+            status, code, error = check_url("https://example.com/file.mp3")
+
+            assert status == URLStatus.OK
+            assert code == 200
+            assert error is None
+
+    @pytest.mark.description("check_url returns NOT_FOUND for 404")
+    def test_not_found_url(self) -> None:
+        with patch("requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            mock_head.return_value = mock_response
+            mock_head.side_effect = requests.HTTPError(response=mock_response)
+
+            status, code, error = check_url("https://example.com/missing.mp3")
+
+            assert status == URLStatus.NOT_FOUND
+            assert code == 404
+
+    @pytest.mark.description("check_url handles timeout")
+    def test_timeout(self) -> None:
+        with patch("requests.head") as mock_head:
+            mock_head.side_effect = Timeout()
+
+            status, code, error = check_url("https://slow.example.com/file.mp3")
+
+            assert status == URLStatus.TIMEOUT
+            assert code is None
+
+class TestFindEpisodeInRss:
+    @pytest.mark.description("find_episode_in_rss matches by GUID")
+    def test_match_by_guid(self) -> None:
+        episode = MagicMock()
+        episode.guid = "unique-guid-123"
+        episode.title = "Episode Title"
+
+        rss_items = [
+            {"guid": "other-guid", "title": "Other Episode"},
+            {"guid": "unique-guid-123", "title": "Episode Title", "enclosure": {"@url": "new-url"}},
+        ]
+
+        result = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert result["guid"] == "unique-guid-123"
+
+    @pytest.mark.description("find_episode_in_rss falls back to title match")
+    def test_fallback_to_title(self) -> None:
+        episode = MagicMock()
+        episode.guid = "old-guid"
+        episode.title = "Episode Title"
+
+        rss_items = [
+            {"guid": "new-guid", "title": "Episode Title", "enclosure": {"@url": "new-url"}},
+        ]
+
+        result = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert result["title"] == "Episode Title"
+```
+
+Create `tests/integration/test_url_health.py`:
+```python
+pytestmark = pytest.mark.integration
+
+@pytest.mark.description("URL refresh preserves episode transcription status")
+async def test_refresh_preserves_transcription(
+    channel: models.Channel,
+    auth_client: TestClient
+) -> None:
+    """Refreshing URL should not affect transcription/embeddings flags."""
+    # Get episode with transcription
+    episode = await models.Episode.objects.filter(
+        channel=channel, transcribed=True
+    ).first()
+
+    old_transcribed = episode.transcribed
+    old_embeddings = episode.embeddings
+
+    # Mock RSS with new URL
+    with patch("voogle.collection.feed._read_channel_feed") as mock_feed:
+        mock_feed.return_value = {
+            "rss": {
+                "channel": {
+                    "item": [
+                        {
+                            "guid": episode.guid,
+                            "title": episode.title,
+                            "enclosure": {"@url": "https://new-cdn.example.com/episode.mp3"}
+                        }
+                    ]
+                }
+            }
+        }
+
+        with patch("voogle.collection.url_health.check_url") as mock_check:
+            mock_check.return_value = (URLStatus.OK, 200, None)
+
+            await url_health.apply_url_refresh(
+                episode,
+                "https://new-cdn.example.com/episode.mp3"
+            )
+
+    # Reload and verify
+    await episode.load()
+    assert episode.url == "https://new-cdn.example.com/episode.mp3"
+    assert episode.transcribed == old_transcribed
+    assert episode.embeddings == old_embeddings
+```
+
+#### Step 8: Update CHANGELOG.md
+
+Add entry documenting the new feature.
+
+---
+
+### Key Design Decisions
+
+1. **HEAD requests for validation**: Use HEAD instead of GET to minimize bandwidth and server load when just checking URL accessibility.
+
+2. **Rate limiting**: 0.5 second delay between URL checks to avoid triggering rate limits on podcast CDNs.
+
+3. **GUID-first matching**: Match episodes by GUID (stable identifier) first, fall back to title only if GUID doesn't match. Log title-based matches as warnings.
+
+4. **Preview before apply**: All URL changes require explicit admin confirmation. Preview shows what will change before any database modifications.
+
+5. **Audit logging**: Log old and new URLs for every refresh to enable rollback if needed.
+
+6. **Preserve transcription state**: URL refresh updates only the `url` field, preserving `transcribed` and `embeddings` status.
+
+7. **No auto-refresh**: All URL changes require explicit admin action. No automatic background refresh.
+
+---
+
+### Files Modified/Created
+
+**Created**:
+- `backend/src/voogle/collection/url_health.py` - URL validation and refresh logic
+
+**Modified**:
+- `backend/src/voogle/management/pages/3_🔈-Media.py` - Add URL health section
+- `CHANGELOG.md` - Document new feature
+
+**Tests Added**:
+- `tests/unit/collection/test_url_health.py` - Unit tests for URL checking/matching
+- `tests/integration/test_url_health.py` - Integration tests for refresh flow
+
+---
+
+### Edge Cases
+
+1. **GUID changed in RSS**: Fall back to title matching, log warning
+2. **Episode removed from RSS**: Cannot refresh, show clear error message
+3. **New URL also 404s**: Reject update, show error in preview
+4. **Rate limiting on HEAD requests**: 0.5s delay, exponential backoff on 429
+5. **Timeout during batch check**: Mark as TIMEOUT status, don't fail entire batch
+6. **Redirect chains**: Follow redirects (allow_redirects=True), detect loops
+
+---
+
+### Success Criteria
+
+- [ ] Admin can detect broken episode URLs in bulk
+- [ ] Admin can preview URL changes before applying
+- [ ] Admin can refresh URLs for a specific channel
+- [ ] URL changes are validated before persisting (new URL must return 200)
+- [ ] Episode transcriptions and embeddings are preserved during URL update
+- [ ] Clear audit trail of URL changes (old URL, new URL, timestamp in logs)
+- [ ] No automatic URL changes - all require explicit admin action
+
+---
+
+### Verification (REQUIRED before marking complete)
+
+Run these commands and confirm ALL pass:
+
+```bash
+# 1. Lint (must pass)
+cd backend && ruff check .
+
+# 2. Unit + Integration tests (must pass)
+pytest tests/ --ignore=tests/e2e -v
+
+# 3. E2E tests (must pass) - requires frontend + backend running
+pytest tests/e2e -v
+```
+
+---
+
+### Brutal Critic Review (Meeting 404 scenario)
+
+**Addressed concerns**:
+1. ✅ **Detection visibility**: Admin sees clear list of broken URLs with status codes
+2. ✅ **Safe by default**: Preview before apply, no automatic changes
+3. ✅ **Audit trail**: All URL changes logged with old/new values
+4. ✅ **Preserve work**: Transcriptions and embeddings untouched by URL refresh
+5. ✅ **Clear errors**: Human-readable error messages for all failure modes
+
+**Not addressed (out of scope)**:
+- Automatic monitoring/alerting for broken URLs (would require scheduled job)
+- Bulk refresh across all channels (can add if needed)
+- URL validation during initial episode ingestion (separate concern)
+
+---
+
+## Previous: YouTube Playlist Ingestion Adapter (Milestone C)
 
 **Goal**: Refactor `yt_playlist_tool.py` into a proper Voogle source adapter at `backend/src/voogle/sources/youtube_playlist.py` that provides three operations: scan (get metadata), sync_media (download audio), and emit_rss (generate local RSS feed for Voogle ingestion).
 

--- a/tests/integration/test_url_health.py
+++ b/tests/integration/test_url_health.py
@@ -1,0 +1,258 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Integration tests for URL health checking and refresh logic."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voogle import models
+from voogle.collection import url_health
+from voogle.collection.url_health import URLStatus
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.description("check_episode_url returns URLHealthResult with episode info")
+async def test_check_episode_url(channel: models.media.Channel) -> None:
+    """Verify check_episode_url returns proper result structure."""
+    _unused = channel  # Creates episodes in DB
+
+    episode = await models.Episode.objects.first()
+    assert episode is not None
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.OK, 200, None)
+
+        result = await url_health.check_episode_url(episode)
+
+        assert result.episode_pk == episode.pk
+        assert result.episode_title == episode.title
+        assert result.url == episode.url
+        assert result.status == URLStatus.OK
+        assert result.http_code == 200
+        assert result.error_message is None
+        assert result.checked_at is not None
+
+
+@pytest.mark.description("check_episode_url captures errors correctly")
+async def test_check_episode_url_error(channel: models.media.Channel) -> None:
+    """Verify check_episode_url captures error details."""
+    _unused = channel
+
+    episode = await models.Episode.objects.first()
+    assert episode is not None
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.NOT_FOUND, 404, "URL not found")
+
+        result = await url_health.check_episode_url(episode)
+
+        assert result.status == URLStatus.NOT_FOUND
+        assert result.http_code == 404
+        assert result.error_message == "URL not found"
+
+
+@pytest.mark.description("check_channel_urls checks all episodes in channel")
+async def test_check_channel_urls(channel: models.media.Channel) -> None:
+    """Verify all channel episodes are checked."""
+    episode_count = await models.Episode.objects.filter(channel=channel).count()
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.OK, 200, None)
+
+        results = await url_health.check_channel_urls(channel)
+
+        assert len(results) == episode_count
+        assert mock_check.call_count == episode_count
+
+
+@pytest.mark.description("check_channel_urls calls progress callback")
+async def test_check_channel_urls_progress(channel: models.media.Channel) -> None:
+    """Verify progress callback is called correctly."""
+    episode_count = await models.Episode.objects.filter(channel=channel).count()
+    progress_calls = []
+
+    def on_progress(checked: int, total: int) -> None:
+        progress_calls.append((checked, total))
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.OK, 200, None)
+
+        await url_health.check_channel_urls(channel, on_progress=on_progress)
+
+        assert len(progress_calls) == episode_count
+        # Verify progress is incremental
+        for i, (checked, total) in enumerate(progress_calls):
+            assert checked == i + 1
+            assert total == episode_count
+
+
+@pytest.mark.description("check_all_broken_urls returns only broken episodes")
+async def test_check_all_broken_urls(channel: models.media.Channel) -> None:
+    """Verify only broken URLs are returned."""
+    _unused = channel
+    episode_count = await models.Episode.objects.count()
+    call_count = 0
+
+    def mock_check_side_effect(url: str, timeout: int = 10) -> tuple:
+        nonlocal call_count
+        call_count += 1
+        # Make first episode broken, rest OK
+        if call_count == 1:
+            return (URLStatus.NOT_FOUND, 404, "URL not found")
+        return (URLStatus.OK, 200, None)
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.side_effect = mock_check_side_effect
+
+        results = await url_health.check_all_broken_urls()
+
+        # Should only return the one broken URL
+        assert len(results) == 1
+        assert results[0].status == URLStatus.NOT_FOUND
+        # But all episodes should have been checked
+        assert mock_check.call_count == episode_count
+
+
+@pytest.mark.description("find_updated_url finds new URL from RSS feed")
+async def test_find_updated_url(channel: models.media.Channel) -> None:
+    """Verify finding updated URL from RSS feed."""
+    episode = await models.Episode.objects.filter(channel=channel).first()
+    assert episode is not None
+
+    new_url = "https://new-cdn.example.com/episode.mp3"
+
+    with patch("voogle.collection.url_health.feed._read_channel_feed") as mock_feed:
+        mock_feed.return_value = {
+            "rss": {
+                "channel": {
+                    "item": [
+                        {
+                            "guid": episode.guid,
+                            "title": episode.title,
+                            "enclosure": {"@url": new_url},
+                        }
+                    ]
+                }
+            }
+        }
+
+        with patch("voogle.collection.url_health.check_url") as mock_check:
+            mock_check.return_value = (URLStatus.OK, 200, None)
+
+            result = await url_health.find_updated_url(episode, channel)
+
+            assert result.episode_pk == episode.pk
+            assert result.old_url == episode.url
+            assert result.new_url == new_url
+            assert result.match_method == "guid"
+            assert result.new_url_valid is True
+            assert result.error_message is None
+
+
+@pytest.mark.description("find_updated_url handles RSS feed fetch failure")
+async def test_find_updated_url_feed_failure(channel: models.media.Channel) -> None:
+    """Verify handling of RSS feed fetch failure."""
+    episode = await models.Episode.objects.filter(channel=channel).first()
+    assert episode is not None
+
+    with patch("voogle.collection.url_health.feed._read_channel_feed") as mock_feed:
+        mock_feed.return_value = None
+
+        result = await url_health.find_updated_url(episode, channel)
+
+        assert result.new_url is None
+        assert result.new_url_valid is False
+        assert "Failed to fetch RSS feed" in result.error_message
+
+
+@pytest.mark.description("find_updated_url handles episode not found in RSS")
+async def test_find_updated_url_episode_not_found(channel: models.media.Channel) -> None:
+    """Verify handling when episode is not in current RSS."""
+    episode = await models.Episode.objects.filter(channel=channel).first()
+    assert episode is not None
+
+    with patch("voogle.collection.url_health.feed._read_channel_feed") as mock_feed:
+        mock_feed.return_value = {
+            "rss": {
+                "channel": {
+                    "item": [
+                        {
+                            "guid": "different-guid",
+                            "title": "Different Episode",
+                            "enclosure": {"@url": "https://other.mp3"},
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = await url_health.find_updated_url(episode, channel)
+
+        assert result.new_url is None
+        assert "not found in current RSS feed" in result.error_message
+
+
+@pytest.mark.description("apply_url_refresh updates episode URL in database")
+async def test_apply_url_refresh(channel: models.media.Channel) -> None:
+    """Verify URL refresh updates database correctly."""
+    episode = await models.Episode.objects.filter(channel=channel).first()
+    assert episode is not None
+
+    old_url = episode.url
+    new_url = "https://new-cdn.example.com/updated.mp3"
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.OK, 200, None)
+
+        await url_health.apply_url_refresh(episode, new_url)
+
+    # Reload from database
+    updated_episode = await models.Episode.objects.get(pk=episode.pk)
+    assert updated_episode.url == new_url
+    assert updated_episode.url != old_url
+
+
+@pytest.mark.description("apply_url_refresh preserves transcription status")
+async def test_apply_url_refresh_preserves_status(channel: models.media.Channel) -> None:
+    """Verify URL refresh preserves transcription and embeddings status."""
+    episode = await models.Episode.objects.filter(channel=channel).first()
+    assert episode is not None
+
+    # Set transcribed and embeddings flags
+    await episode.update(transcribed=True, embeddings=True)
+
+    new_url = "https://new-cdn.example.com/updated.mp3"
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.OK, 200, None)
+
+        await url_health.apply_url_refresh(episode, new_url)
+
+    # Reload and verify status preserved
+    updated_episode = await models.Episode.objects.get(pk=episode.pk)
+    assert updated_episode.url == new_url
+    assert updated_episode.transcribed is True
+    assert updated_episode.embeddings is True
+
+
+@pytest.mark.description("apply_url_refresh rejects inaccessible new URL")
+async def test_apply_url_refresh_rejects_bad_url(channel: models.media.Channel) -> None:
+    """Verify URL refresh rejects inaccessible new URLs."""
+    episode = await models.Episode.objects.filter(channel=channel).first()
+    assert episode is not None
+
+    old_url = episode.url
+    new_url = "https://broken.example.com/404.mp3"
+
+    with patch("voogle.collection.url_health.check_url") as mock_check:
+        mock_check.return_value = (URLStatus.NOT_FOUND, 404, "URL not found")
+
+        with pytest.raises(ValueError, match="not accessible"):
+            await url_health.apply_url_refresh(episode, new_url)
+
+    # Verify URL was NOT changed
+    unchanged_episode = await models.Episode.objects.get(pk=episode.pk)
+    assert unchanged_episode.url == old_url

--- a/tests/unit/collection/__init__.py
+++ b/tests/unit/collection/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.

--- a/tests/unit/collection/test_url_health.py
+++ b/tests/unit/collection/test_url_health.py
@@ -1,0 +1,250 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Unit tests for URL health checking and refresh logic."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from voogle.collection.url_health import (
+    URLStatus,
+    check_url,
+    find_episode_in_rss,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestCheckUrl:
+    """Tests for the check_url function."""
+
+    @pytest.mark.description("check_url returns OK for accessible URLs")
+    def test_accessible_url(self) -> None:
+        """Accessible URL should return OK status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_head.return_value = mock_response
+
+            status, code, error = check_url("https://example.com/file.mp3")
+
+            assert status == URLStatus.OK
+            assert code == 200
+            assert error is None
+            mock_head.assert_called_once()
+
+    @pytest.mark.description("check_url returns NOT_FOUND for 404 responses")
+    def test_not_found_url(self) -> None:
+        """404 response should return NOT_FOUND status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 404
+            error = requests.HTTPError(response=mock_response)
+            mock_head.side_effect = error
+
+            status, code, error_msg = check_url("https://example.com/missing.mp3")
+
+            assert status == URLStatus.NOT_FOUND
+            assert code == 404
+            assert error_msg == "URL not found"
+
+    @pytest.mark.description("check_url returns FORBIDDEN for 403 responses")
+    def test_forbidden_url(self) -> None:
+        """403 response should return FORBIDDEN status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 403
+            error = requests.HTTPError(response=mock_response)
+            mock_head.side_effect = error
+
+            status, code, error_msg = check_url("https://example.com/private.mp3")
+
+            assert status == URLStatus.FORBIDDEN
+            assert code == 403
+            assert error_msg == "Access forbidden"
+
+    @pytest.mark.description("check_url returns SERVER_ERROR for 5xx responses")
+    def test_server_error_url(self) -> None:
+        """5xx response should return SERVER_ERROR status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 503
+            error = requests.HTTPError(response=mock_response)
+            mock_head.side_effect = error
+
+            status, code, error_msg = check_url("https://example.com/file.mp3")
+
+            assert status == URLStatus.SERVER_ERROR
+            assert code == 503
+            assert "503" in error_msg
+
+    @pytest.mark.description("check_url returns TIMEOUT when request times out")
+    def test_timeout(self) -> None:
+        """Timeout should return TIMEOUT status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_head.side_effect = requests.exceptions.Timeout()
+
+            status, code, error_msg = check_url("https://slow.example.com/file.mp3")
+
+            assert status == URLStatus.TIMEOUT
+            assert code is None
+            assert error_msg == "Request timed out"
+
+    @pytest.mark.description("check_url returns CONNECTION_ERROR when host unreachable")
+    def test_connection_error(self) -> None:
+        """Connection error should return CONNECTION_ERROR status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_head.side_effect = requests.exceptions.ConnectionError()
+
+            status, code, error_msg = check_url("https://unreachable.example.com/file.mp3")
+
+            assert status == URLStatus.CONNECTION_ERROR
+            assert code is None
+            assert error_msg == "Host unreachable"
+
+    @pytest.mark.description("check_url returns REDIRECT_LOOP for too many redirects")
+    def test_redirect_loop(self) -> None:
+        """Too many redirects should return REDIRECT_LOOP status."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_head.side_effect = requests.exceptions.TooManyRedirects()
+
+            status, code, error_msg = check_url("https://loop.example.com/file.mp3")
+
+            assert status == URLStatus.REDIRECT_LOOP
+            assert code is None
+            assert error_msg == "Too many redirects"
+
+    @pytest.mark.description("check_url uses correct timeout and headers")
+    def test_request_parameters(self) -> None:
+        """Verify correct request parameters are used."""
+        with patch("voogle.collection.url_health.requests.head") as mock_head:
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_head.return_value = mock_response
+
+            check_url("https://example.com/file.mp3", timeout=15)
+
+            mock_head.assert_called_once_with(
+                "https://example.com/file.mp3",
+                timeout=15,
+                allow_redirects=True,
+                headers={"User-Agent": "Voogle/1.0 (URL Health Check)"},
+            )
+
+
+class TestFindEpisodeInRss:
+    """Tests for the find_episode_in_rss function."""
+
+    @pytest.mark.description("find_episode_in_rss matches by GUID first")
+    def test_match_by_guid(self) -> None:
+        """Episode should match by GUID."""
+        episode = MagicMock()
+        episode.guid = "unique-guid-123"
+        episode.title = "Episode Title"
+
+        rss_items = [
+            {"guid": "other-guid", "title": "Other Episode"},
+            {"guid": "unique-guid-123", "title": "Different Title", "enclosure": {"@url": "new-url"}},
+        ]
+
+        result, method = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert result["guid"] == "unique-guid-123"
+        assert method == "guid"
+
+    @pytest.mark.description("find_episode_in_rss falls back to title match")
+    def test_fallback_to_title(self) -> None:
+        """When GUID doesn't match, should fall back to title."""
+        episode = MagicMock()
+        episode.guid = "old-guid"
+        episode.title = "Episode Title"
+
+        rss_items = [
+            {"guid": "new-guid", "title": "Episode Title", "enclosure": {"@url": "new-url"}},
+        ]
+
+        result, method = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert result["title"] == "Episode Title"
+        assert method == "title"
+
+    @pytest.mark.description("find_episode_in_rss returns None when no match")
+    def test_no_match(self) -> None:
+        """No match should return None."""
+        episode = MagicMock()
+        episode.guid = "my-guid"
+        episode.title = "My Episode"
+
+        rss_items = [
+            {"guid": "other-guid", "title": "Other Episode"},
+            {"guid": "another-guid", "title": "Another Episode"},
+        ]
+
+        result, method = find_episode_in_rss(episode, rss_items)
+
+        assert result is None
+        assert method is None
+
+    @pytest.mark.description("find_episode_in_rss handles case-insensitive title match")
+    def test_case_insensitive_title(self) -> None:
+        """Title matching should be case-insensitive."""
+        episode = MagicMock()
+        episode.guid = "no-match-guid"
+        episode.title = "EPISODE TITLE"
+
+        rss_items = [
+            {"guid": "other-guid", "title": "episode title", "enclosure": {"@url": "url"}},
+        ]
+
+        result, method = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert method == "title"
+
+    @pytest.mark.description("find_episode_in_rss handles dict GUID format")
+    def test_dict_guid_format(self) -> None:
+        """Should handle GUID as dict with #text key (xmltodict format)."""
+        episode = MagicMock()
+        episode.guid = "unique-guid-123"
+        episode.title = "Episode Title"
+
+        rss_items = [
+            {"guid": {"#text": "unique-guid-123", "@isPermaLink": "false"}, "title": "Title"},
+        ]
+
+        result, method = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert method == "guid"
+
+    @pytest.mark.description("find_episode_in_rss handles empty RSS items")
+    def test_empty_rss_items(self) -> None:
+        """Empty RSS items list should return None."""
+        episode = MagicMock()
+        episode.guid = "guid"
+        episode.title = "Title"
+
+        result, method = find_episode_in_rss(episode, [])
+
+        assert result is None
+        assert method is None
+
+    @pytest.mark.description("find_episode_in_rss handles missing guid in RSS item")
+    def test_missing_guid_in_item(self) -> None:
+        """Should handle RSS items without GUID and fall back to title."""
+        episode = MagicMock()
+        episode.guid = "my-guid"
+        episode.title = "My Episode"
+
+        rss_items = [
+            {"title": "My Episode", "enclosure": {"@url": "url"}},  # No guid
+        ]
+
+        result, method = find_episode_in_rss(episode, rss_items)
+
+        assert result is not None
+        assert method == "title"


### PR DESCRIPTION
## Summary

- Add capability to detect and refresh broken episode media URLs without losing transcription/embedding work
- New `url_health.py` module with URL validation (HEAD requests) and RSS-based URL refresh logic
- Streamlit admin UI with 3 sections: Detect Broken URLs, Preview URL Refresh, Apply URL Refresh
- GUID-first episode matching with title fallback for robust RSS item identification

## Changes

**New files:**
- `backend/src/voogle/collection/url_health.py` - Core URL health checking and refresh logic
- `tests/unit/collection/test_url_health.py` - 15 unit tests
- `tests/integration/test_url_health.py` - 11 integration tests

**Modified files:**
- `backend/src/voogle/collection/__init__.py` - Added exports
- `backend/src/voogle/management/pages/3_🔈-Media.py` - Admin UI section
- `CHANGELOG.md` - Feature documentation
- `docs/plan.md` - Implementation plan

## Safety features

- Rate limiting (0.5s delay between requests) to avoid CDN rate limits
- Audit logging of all URL changes (old URL → new URL)
- Preserves transcription and embeddings status during refresh
- All changes require explicit admin confirmation with preview

## Test plan

- [x] Unit tests pass (15 tests for `check_url()`, `find_episode_in_rss()`)
- [x] Integration tests pass (11 tests for database operations)
- [x] Lint passes (`ruff check .`)
- [ ] E2E tests (requires full stack running)
- [ ] Manual testing of Streamlit UI

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)