### PR TITLE
feat: add local RAG answer endpoint with CLI tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Format: **WHAT** changed, **WHY** it changed, and any **REASONING** behind decis
 ## [Unreleased]
 
 ### Added
+- **Local RAG answer endpoint with CLI tools** (#33)
+  - New `/assistant/answer_local` endpoint for local-only RAG queries
+  - Retrieves relevant fragments via existing search, builds prompts with citations
+  - Shells out to user-installed `claude` or `codex` CLI for answer generation
+  - Three-layer security architecture (defense in depth):
+    1. Feature flag `LOCAL_ASSISTANT_ENABLED=false` by default
+    2. Network origin guard (localhost or explicit allowlist only)
+    3. Subprocess safety (shutil.which validation, no shell injection)
+  - New settings: `LOCAL_ASSISTANT_ENABLED`, `LOCAL_ASSISTANT_ALLOWLIST`, `LOCAL_ASSISTANT_CLI_TIMEOUT`, `LOCAL_ASSISTANT_CLI_PREFERENCE`
+  - Streamlit warning banner when feature is enabled
+  - Response includes answer text plus source citations with media URLs
+
+**WHY**: Enables zero-API-cost local development and testing of RAG functionality using pre-installed CLI tools. Users can query their indexed podcast transcripts and get answers with citations without any external API calls.
+
+**REASONING**: Disabled by default with multiple guard layers ensures zero chance of accidental production exposure. Localhost-only by default prevents security issues. CLI detection fails loud (no silent fallbacks). Uses existing search infrastructure to minimize code duplication.
+
 - **Multi-provider embeddings with consistent metadata** (#25)
   - `EmbeddingsProvider.model_name` and `provider_name` properties for tracking
   - Qdrant payload now includes `embedding_model`, `embedding_provider`, `embedded_at`

--- a/backend/src/voogle/main.py
+++ b/backend/src/voogle/main.py
@@ -42,5 +42,6 @@ app.include_router(routers.users.router)
 app.include_router(routers.media.router)
 app.include_router(routers.analytics.router)
 app.include_router(routers.local.router)
+app.include_router(routers.assistant.router)
 
 add_pagination(app)

--- a/backend/src/voogle/management/🏠-Home.py
+++ b/backend/src/voogle/management/🏠-Home.py
@@ -4,12 +4,21 @@
 
 import streamlit as st
 
-from voogle import __version__
+from voogle import __version__, settings
 from voogle.management import utils
 
 st.set_page_config(page_title="Voogle", page_icon="🎧")
 st.title("🎧 Voogle Management Dashboard")
 authenticated = utils.login_message(st.session_state)  # type: ignore[arg-type]
+
+# SECURITY WARNING: Local Assistant is enabled
+if settings.settings.local_assistant_enabled:
+    st.error(
+        "**SECURITY WARNING**: Local Assistant is ENABLED\n\n"
+        "The `/assistant/answer_local` endpoint is accessible. This feature shells out to "
+        "CLI tools and should ONLY be used on trusted local machines.\n\n"
+        "Set `LOCAL_ASSISTANT_ENABLED=false` to disable."
+    )
 
 st.markdown(
     f"""**Management tools for Voogle deployments.**

--- a/backend/src/voogle/routers/__init__.py
+++ b/backend/src/voogle/routers/__init__.py
@@ -5,6 +5,7 @@
 
 from . import analytics as analytics
 from . import app as app
+from . import assistant as assistant
 from . import local as local
 from . import media as media
 from . import users as users

--- a/backend/src/voogle/routers/assistant.py
+++ b/backend/src/voogle/routers/assistant.py
@@ -1,0 +1,261 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Router for local assistant endpoint with CLI tools.
+
+This module provides a local-only RAG (Retrieval-Augmented Generation) endpoint
+that retrieves relevant fragments from the vector database, builds a prompt with
+citations, and shells out to user-installed CLI tools (claude or codex) for
+answer generation.
+
+SECURITY: This feature has multiple guard layers:
+1. Feature flag (LOCAL_ASSISTANT_ENABLED) must be explicitly enabled
+2. Request must come from localhost OR be in explicit allowlist
+3. CLI execution uses subprocess.run with list args (no shell injection)
+"""
+
+import logging
+import shutil
+import subprocess
+from typing import Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from voogle import settings as app_settings
+from voogle import storage, tasks
+from voogle.models import media
+from voogle.models.media import ChannelKind
+from voogle.schemas import assistant as assistant_schemas
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/assistant", tags=["assistant"])
+
+
+def require_local_assistant_enabled() -> None:
+    """Guard Layer 1: Feature flag must be explicitly enabled.
+
+    Raises HTTPException 503 if LOCAL_ASSISTANT_ENABLED is not true.
+    """
+    if not app_settings.settings.local_assistant_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="Local assistant feature is not enabled. "
+            "Set LOCAL_ASSISTANT_ENABLED=true to enable.",
+        )
+
+
+def require_localhost_or_allowlist(request: Request) -> None:
+    """Guard Layer 2: Must be localhost or explicitly allowlisted.
+
+    Raises HTTPException 403 if request is not from localhost and not in allowlist.
+    """
+    client_host = request.client.host if request.client else None
+    if client_host is None:
+        raise HTTPException(status_code=403, detail="Cannot determine client IP")
+
+    # Check localhost (IPv4 and IPv6)
+    localhost_ips = {"127.0.0.1", "::1"}
+    if client_host in localhost_ips:
+        return
+
+    # Check allowlist
+    allowlist = app_settings.settings.local_assistant_allowlist
+    if allowlist:
+        allowed_ips = {ip.strip() for ip in allowlist.split(",") if ip.strip()}
+        if client_host in allowed_ips:
+            return
+
+    raise HTTPException(
+        status_code=403,
+        detail=f"Access denied: {client_host} is not localhost or allowlisted",
+    )
+
+
+def find_cli_tool() -> str:
+    """Find available CLI tool. Fails loud if none found.
+
+    Returns the name of the CLI tool to use (either the preferred one or fallback).
+
+    Raises HTTPException 503 if neither claude nor codex is found in PATH.
+    """
+    preferred = app_settings.settings.local_assistant_cli_preference
+
+    # Try preferred first
+    if shutil.which(preferred):
+        return preferred
+
+    # Try alternative
+    alternative = "codex" if preferred == "claude" else "claude"
+    if shutil.which(alternative):
+        logger.info(f"Preferred CLI '{preferred}' not found, using '{alternative}'")
+        return alternative
+
+    raise HTTPException(
+        status_code=503,
+        detail=f"Neither '{preferred}' nor '{alternative}' CLI found in PATH. "
+        f"Install one from: https://github.com/anthropics/claude-code "
+        f"or https://github.com/openai/codex-cli",
+    )
+
+
+def execute_cli(cli: str, prompt: str) -> str:
+    """Execute CLI with prompt via stdin. Fails loud on errors.
+
+    Args:
+        cli: Name of the CLI tool to execute
+        prompt: The prompt to send via stdin
+
+    Returns:
+        The CLI's stdout response
+
+    Raises:
+        HTTPException 500 if CLI fails or times out
+    """
+    timeout = app_settings.settings.local_assistant_cli_timeout
+
+    try:
+        result = subprocess.run(
+            [cli, "--print"],  # --print for non-interactive output
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as err:
+        raise HTTPException(
+            status_code=500,
+            detail=f"CLI '{cli}' timed out after {timeout} seconds",
+        ) from err
+    except FileNotFoundError as err:
+        # Should not happen since we check with shutil.which, but handle anyway
+        raise HTTPException(
+            status_code=503,
+            detail=f"CLI '{cli}' not found",
+        ) from err
+
+    if result.returncode != 0:
+        raise HTTPException(
+            status_code=500,
+            detail=f"CLI '{cli}' failed with exit code {result.returncode}: {result.stderr}",
+        )
+
+    return result.stdout
+
+
+def build_prompt(
+    query: str, sources: list[assistant_schemas.SourceCitation]
+) -> str:
+    """Build the prompt for the CLI with citations.
+
+    Args:
+        query: The user's question
+        sources: List of source citations from search results
+
+    Returns:
+        Formatted prompt string
+    """
+    if not sources:
+        return f"""The user asked: {query}
+
+Unfortunately, no relevant sources were found in the database.
+Please respond that you cannot answer this question as there are no
+relevant transcript excerpts available."""
+
+    source_text = "\n\n".join(
+        f"[{s.index}] Episode: {s.episode_title} | Channel: {s.channel_title} | "
+        f"Timestamp: {s.start_secs:.0f}s-{s.end_secs:.0f}s\n{s.text}"
+        for s in sources
+    )
+
+    return f"""Based on the following transcript excerpts, answer the question.
+
+Question: {query}
+
+Sources:
+{source_text}
+
+Instructions:
+- Answer the question based ONLY on the provided sources
+- Cite sources using [1], [2], etc. when referencing specific information
+- If the sources don't contain relevant information, say so clearly"""
+
+
+@router.get(
+    "/answer_local",
+    summary="Get an answer using local CLI tools (claude/codex)",
+    response_model=assistant_schemas.LocalAnswerResponse,
+    dependencies=[
+        Depends(require_local_assistant_enabled),
+        Depends(require_localhost_or_allowlist),
+    ],
+)
+async def answer_local(
+    query_text: str,
+    k: int = 6,
+    channel_id: Optional[UUID] = None,
+) -> assistant_schemas.LocalAnswerResponse:
+    """Get an answer to a query using local CLI tools.
+
+    This endpoint:
+    1. Searches the vector database for relevant fragments
+    2. Builds a prompt with citations
+    3. Executes a local CLI tool (claude or codex) with the prompt
+    4. Returns the answer with source citations
+
+    Args:
+        query_text: The question to answer
+        k: Number of search results to include (default 6)
+        channel_id: Optional channel to scope the search
+
+    Returns:
+        LocalAnswerResponse with answer text and source citations
+    """
+    # Find CLI tool (fails loud if none found)
+    cli = find_cli_tool()
+
+    # Search for relevant fragments (reuses existing search logic)
+    channel_pk = None
+    if channel_id:
+        channel = await media.Channel.objects.get(id=channel_id)
+        channel_pk = channel.pk
+
+    search_results = tasks.search(query_text, k, channel=channel_pk)
+
+    # Build source citations
+    sources: list[assistant_schemas.SourceCitation] = []
+    for idx, r in enumerate(search_results, start=1):
+        episode = await media.Episode.objects.get(pk=r.episode)
+        if episode.channel is None:
+            logger.warning(f"Episode {episode.pk} has no associated channel, skipping")
+            continue
+        channel = await episode.channel.load()
+
+        # Use local media URL for local channels, original URL for podcast channels
+        if channel.kind == ChannelKind.local.value:
+            media_url = storage.local_media_url(channel, episode)
+        else:
+            media_url = str(episode.url)
+
+        sources.append(
+            assistant_schemas.SourceCitation(
+                index=idx,
+                episode_title=str(episode.title),
+                channel_title=str(channel.title),
+                start_secs=r.start_secs,
+                end_secs=r.end_secs,
+                text=r.text,
+                media_url=media_url,
+            )
+        )
+
+    # Build prompt and execute CLI
+    prompt = build_prompt(query_text, sources)
+    answer = execute_cli(cli, prompt)
+
+    return assistant_schemas.LocalAnswerResponse(
+        answer=answer.strip(),
+        sources=sources,
+        cli_used=cli,
+        query=query_text,
+    )

--- a/backend/src/voogle/schemas/__init__.py
+++ b/backend/src/voogle/schemas/__init__.py
@@ -3,5 +3,6 @@
 # All rights reserved.
 
 from . import analytics as analytics
+from . import assistant as assistant
 from . import media as media
 from . import users as users

--- a/backend/src/voogle/schemas/assistant.py
+++ b/backend/src/voogle/schemas/assistant.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Schemas for local assistant endpoint."""
+
+from pydantic import BaseModel
+
+
+class SourceCitation(BaseModel):
+    """A source citation from a search result fragment."""
+
+    index: int  # [1], [2], etc.
+    episode_title: str
+    channel_title: str
+    start_secs: float
+    end_secs: float
+    text: str
+    media_url: str
+
+
+class LocalAnswerResponse(BaseModel):
+    """Response from the local assistant endpoint."""
+
+    answer: str  # The CLI-generated answer
+    sources: list[SourceCitation]
+    cli_used: str  # "claude" or "codex"
+    query: str  # Original query for reference

--- a/backend/src/voogle/settings.py
+++ b/backend/src/voogle/settings.py
@@ -65,6 +65,14 @@ class Settings(BaseSettings):
     youtube_audio_format: str = "mp3"
     youtube_cookies_file: Optional[str] = None  # path to cookies.txt for auth
 
+    # Local Assistant Configuration
+    # CRITICAL: Feature is disabled by default and requires explicit enablement
+    # This feature shells out to CLI tools and should ONLY be used on trusted local machines
+    local_assistant_enabled: bool = False
+    local_assistant_allowlist: str = ""  # Comma-separated IPs, e.g., "192.168.1.100,10.0.0.5"
+    local_assistant_cli_timeout: int = 60  # Seconds to wait for CLI response
+    local_assistant_cli_preference: str = "claude"  # "claude" or "codex"
+
     @property
     def data_dir(self) -> pathlib.Path:
         # In Docker (both dev and prod), data is always mounted at /data

--- a/tests/integration/test_assistant.py
+++ b/tests/integration/test_assistant.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Integration tests for local assistant endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+from voogle import embedding, models, storage, transcription, vector
+
+pytestmark = pytest.mark.integration
+
+# TestClient uses "testclient" as the client host, so we need to allowlist it
+# for tests that need to pass the localhost check
+TESTCLIENT_ALLOWLIST = "testclient"
+
+
+@pytest.mark.description("Feature disabled returns 503")
+def test_feature_disabled_returns_503(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When LOCAL_ASSISTANT_ENABLED=false, endpoint returns 503."""
+    from voogle import settings as settings_module
+
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", False)
+
+    response = client.get("/assistant/answer_local?query_text=test")
+
+    assert response.status_code == 503
+    assert "not enabled" in response.json()["detail"]
+
+
+@pytest.mark.description("Feature enabled but CLI not found returns 503")
+def test_cli_not_found_returns_503(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When feature enabled but no CLI found, returns 503."""
+    from voogle import settings as settings_module
+
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+    # Allowlist testclient to pass the localhost check
+    monkeypatch.setattr(
+        settings_module.settings, "local_assistant_allowlist", TESTCLIENT_ALLOWLIST
+    )
+
+    with patch("voogle.routers.assistant.shutil.which", return_value=None):
+        response = client.get("/assistant/answer_local?query_text=test")
+
+    assert response.status_code == 503
+    assert "CLI" in response.json()["detail"]
+    assert "PATH" in response.json()["detail"]
+
+
+@pytest.mark.description("Full flow with mocked CLI execution")
+async def test_answer_local_full_flow(
+    fake_channel: models.media.Channel,
+    fake_episode: models.media.Episode,
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test complete flow: search → prompt → mocked CLI → response."""
+    from voogle import settings as settings_module
+
+    # Enable feature and allowlist testclient
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+    monkeypatch.setattr(
+        settings_module.settings, "local_assistant_allowlist", TESTCLIENT_ALLOWLIST
+    )
+    monkeypatch.setattr(settings_module.settings, "local_assistant_cli_timeout", 60)
+
+    # Set up embeddings using configured client
+    provider = embedding.get_embeddings_provider()
+    qdrant_client = vector.get_configured_client()
+    collection_name = vector.get_collection_name(
+        settings_module.settings.embeddings_provider
+    )
+
+    vector.ensure_collection(
+        qdrant_client, collection_name, provider.get_embedding_dimension()
+    )
+
+    # Calculate and store embeddings
+    tr = transcription.read_transcription(await storage.transcription_file(fake_episode))
+    embs, fragments = embedding._transcription_embeddings(
+        tr, provider, embedding.DEFAULT_FRAGMENT_WORDS
+    )
+    await vector.add_episode(
+        fake_episode, qdrant_client, embs, collection_name, fragments
+    )
+
+    # Mock CLI execution
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "Based on the sources, golf is a sport played outdoors. [1]"
+    mock_result.stderr = ""
+
+    def mock_which(cmd: str) -> str | None:
+        return "/usr/bin/claude" if cmd == "claude" else None
+
+    with patch("voogle.routers.assistant.shutil.which", side_effect=mock_which):
+        with patch("voogle.routers.assistant.subprocess.run", return_value=mock_result):
+            response = client.get("/assistant/answer_local?query_text=golf&k=3")
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "answer" in data
+    assert "sources" in data
+    assert "cli_used" in data
+    assert "query" in data
+
+    assert data["cli_used"] == "claude"
+    assert data["query"] == "golf"
+    assert len(data["sources"]) > 0
+
+    # Verify source structure
+    source = data["sources"][0]
+    assert "index" in source
+    assert "episode_title" in source
+    assert "channel_title" in source
+    assert "start_secs" in source
+    assert "end_secs" in source
+    assert "text" in source
+    assert "media_url" in source
+
+
+@pytest.mark.description("Empty search results handled gracefully")
+async def test_empty_search_results(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When search returns no results, response is still valid."""
+    from voogle import settings as settings_module
+
+    # Enable feature and allowlist testclient
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+    monkeypatch.setattr(
+        settings_module.settings, "local_assistant_allowlist", TESTCLIENT_ALLOWLIST
+    )
+    monkeypatch.setattr(settings_module.settings, "local_assistant_cli_timeout", 60)
+
+    # Mock CLI execution
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = "No relevant sources found to answer this question."
+    mock_result.stderr = ""
+
+    def mock_which(cmd: str) -> str | None:
+        return "/usr/bin/claude" if cmd == "claude" else None
+
+    with patch("voogle.routers.assistant.shutil.which", side_effect=mock_which):
+        with patch("voogle.routers.assistant.subprocess.run", return_value=mock_result):
+            # Mock search to return empty results
+            with patch("voogle.routers.assistant.tasks.search", return_value=[]):
+                response = client.get(
+                    "/assistant/answer_local?query_text=xyznonexistentquery123"
+                )
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["sources"] == []  # No sources found
+    assert data["answer"] == "No relevant sources found to answer this question."
+
+
+@pytest.mark.description("CLI timeout is enforced")
+async def test_cli_timeout_enforced(
+    fake_channel: models.media.Channel,
+    fake_episode: models.media.Episode,
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that subprocess.TimeoutExpired is handled properly."""
+    import subprocess
+
+    from voogle import settings as settings_module
+
+    # Enable feature with short timeout and allowlist testclient
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+    monkeypatch.setattr(
+        settings_module.settings, "local_assistant_allowlist", TESTCLIENT_ALLOWLIST
+    )
+    monkeypatch.setattr(settings_module.settings, "local_assistant_cli_timeout", 1)
+
+    # Set up embeddings
+    provider = embedding.get_embeddings_provider()
+    qdrant_client = vector.get_configured_client()
+    collection_name = vector.get_collection_name(
+        settings_module.settings.embeddings_provider
+    )
+
+    vector.ensure_collection(
+        qdrant_client, collection_name, provider.get_embedding_dimension()
+    )
+
+    tr = transcription.read_transcription(await storage.transcription_file(fake_episode))
+    embs, fragments = embedding._transcription_embeddings(
+        tr, provider, embedding.DEFAULT_FRAGMENT_WORDS
+    )
+    await vector.add_episode(
+        fake_episode, qdrant_client, embs, collection_name, fragments
+    )
+
+    def mock_which(cmd: str) -> str | None:
+        return "/usr/bin/claude" if cmd == "claude" else None
+
+    with patch("voogle.routers.assistant.shutil.which", side_effect=mock_which):
+        with patch(
+            "voogle.routers.assistant.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1),
+        ):
+            response = client.get("/assistant/answer_local?query_text=golf")
+
+    assert response.status_code == 500
+    assert "timed out" in response.json()["detail"]
+
+
+@pytest.mark.description("Non-localhost without allowlist returns 403")
+def test_non_localhost_returns_403(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When feature enabled but request is not from localhost or allowlist, returns 403."""
+    from voogle import settings as settings_module
+
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+    # Empty allowlist - testclient should be rejected
+    monkeypatch.setattr(settings_module.settings, "local_assistant_allowlist", "")
+
+    response = client.get("/assistant/answer_local?query_text=test")
+
+    assert response.status_code == 403
+    assert "not localhost or allowlisted" in response.json()["detail"]
+
+
+@pytest.mark.description("Allowlisted IP is accepted")
+def test_allowlisted_ip_accepted(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When feature enabled and IP is in allowlist, request proceeds to CLI check."""
+    from voogle import settings as settings_module
+
+    # Enable feature with allowlist for testclient
+    monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+    monkeypatch.setattr(
+        settings_module.settings, "local_assistant_allowlist", TESTCLIENT_ALLOWLIST
+    )
+
+    with patch("voogle.routers.assistant.shutil.which", return_value=None):
+        response = client.get("/assistant/answer_local?query_text=test")
+
+    # Should reach CLI check (503), not IP check (403)
+    assert response.status_code == 503
+    assert "CLI" in response.json()["detail"]
+    assert "PATH" in response.json()["detail"]

--- a/tests/unit/test_assistant.py
+++ b/tests/unit/test_assistant.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Unit tests for local assistant functionality."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from voogle.routers import assistant
+from voogle.schemas.assistant import SourceCitation
+
+pytestmark = pytest.mark.unit
+
+
+class TestRequireLocalAssistantEnabled:
+    """Tests for the feature flag guard layer."""
+
+    @pytest.mark.description("Feature disabled raises 503")
+    def test_feature_disabled_raises_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When LOCAL_ASSISTANT_ENABLED=false, raises HTTPException 503."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", False)
+
+        with pytest.raises(HTTPException) as exc_info:
+            assistant.require_local_assistant_enabled()
+
+        assert exc_info.value.status_code == 503
+        assert "not enabled" in exc_info.value.detail
+
+    @pytest.mark.description("Feature enabled passes")
+    def test_feature_enabled_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When LOCAL_ASSISTANT_ENABLED=true, no exception raised."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_enabled", True)
+
+        # Should not raise
+        assistant.require_local_assistant_enabled()
+
+
+class TestRequireLocalhostOrAllowlist:
+    """Tests for the network origin guard layer."""
+
+    @pytest.mark.description("Localhost IPv4 is allowed")
+    def test_localhost_ipv4_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Request from 127.0.0.1 is allowed."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_allowlist", "")
+
+        request = MagicMock()
+        request.client.host = "127.0.0.1"
+
+        # Should not raise
+        assistant.require_localhost_or_allowlist(request)
+
+    @pytest.mark.description("Localhost IPv6 is allowed")
+    def test_localhost_ipv6_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Request from ::1 is allowed."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_allowlist", "")
+
+        request = MagicMock()
+        request.client.host = "::1"
+
+        # Should not raise
+        assistant.require_localhost_or_allowlist(request)
+
+    @pytest.mark.description("Non-localhost without allowlist raises 403")
+    def test_non_localhost_raises_403(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Request from non-localhost IP (not in allowlist) raises 403."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_allowlist", "")
+
+        request = MagicMock()
+        request.client.host = "192.168.1.100"
+
+        with pytest.raises(HTTPException) as exc_info:
+            assistant.require_localhost_or_allowlist(request)
+
+        assert exc_info.value.status_code == 403
+        assert "192.168.1.100" in exc_info.value.detail
+
+    @pytest.mark.description("Allowlisted IP is permitted")
+    def test_allowlisted_ip_permitted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Request from allowlisted IP is allowed."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(
+            settings_module.settings,
+            "local_assistant_allowlist",
+            "192.168.1.100, 10.0.0.5",
+        )
+
+        request = MagicMock()
+        request.client.host = "192.168.1.100"
+
+        # Should not raise
+        assistant.require_localhost_or_allowlist(request)
+
+    @pytest.mark.description("IP not in allowlist raises 403")
+    def test_ip_not_in_allowlist_raises_403(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Request from IP not in allowlist raises 403."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(
+            settings_module.settings,
+            "local_assistant_allowlist",
+            "192.168.1.100, 10.0.0.5",
+        )
+
+        request = MagicMock()
+        request.client.host = "192.168.1.200"  # Not in allowlist
+
+        with pytest.raises(HTTPException) as exc_info:
+            assistant.require_localhost_or_allowlist(request)
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.description("Missing client raises 403")
+    def test_missing_client_raises_403(self) -> None:
+        """Request with no client info raises 403."""
+        request = MagicMock()
+        request.client = None
+
+        with pytest.raises(HTTPException) as exc_info:
+            assistant.require_localhost_or_allowlist(request)
+
+        assert exc_info.value.status_code == 403
+        assert "Cannot determine client IP" in exc_info.value.detail
+
+
+class TestFindCliTool:
+    """Tests for CLI tool detection."""
+
+    @pytest.mark.description("CLI not found raises 503")
+    def test_cli_not_found_raises_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When neither claude nor codex is in PATH, raises 503."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(
+            settings_module.settings, "local_assistant_cli_preference", "claude"
+        )
+
+        with patch("voogle.routers.assistant.shutil.which", return_value=None):
+            with pytest.raises(HTTPException) as exc_info:
+                assistant.find_cli_tool()
+
+            assert exc_info.value.status_code == 503
+            assert "CLI" in exc_info.value.detail
+            assert "PATH" in exc_info.value.detail
+
+    @pytest.mark.description("Preferred CLI is used when available")
+    def test_preferred_cli_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Uses LOCAL_ASSISTANT_CLI_PREFERENCE when available."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(
+            settings_module.settings, "local_assistant_cli_preference", "claude"
+        )
+
+        def mock_which(cmd: str) -> str | None:
+            return "/usr/bin/claude" if cmd == "claude" else None
+
+        with patch("voogle.routers.assistant.shutil.which", side_effect=mock_which):
+            result = assistant.find_cli_tool()
+
+        assert result == "claude"
+
+    @pytest.mark.description("Falls back to alternative CLI")
+    def test_fallback_to_alternative(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to alternative CLI when preferred not available."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(
+            settings_module.settings, "local_assistant_cli_preference", "claude"
+        )
+
+        def mock_which(cmd: str) -> str | None:
+            return "/usr/bin/codex" if cmd == "codex" else None
+
+        with patch("voogle.routers.assistant.shutil.which", side_effect=mock_which):
+            result = assistant.find_cli_tool()
+
+        assert result == "codex"
+
+    @pytest.mark.description("Codex preference honored")
+    def test_codex_preference_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When codex is preferred and available, it is used."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(
+            settings_module.settings, "local_assistant_cli_preference", "codex"
+        )
+
+        def mock_which(cmd: str) -> str | None:
+            return f"/usr/bin/{cmd}"  # Both available
+
+        with patch("voogle.routers.assistant.shutil.which", side_effect=mock_which):
+            result = assistant.find_cli_tool()
+
+        assert result == "codex"
+
+
+class TestExecuteCli:
+    """Tests for CLI execution."""
+
+    @pytest.mark.description("Successful CLI execution returns stdout")
+    def test_successful_execution(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Successful CLI execution returns stdout."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_cli_timeout", 60)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "This is the answer."
+        mock_result.stderr = ""
+
+        with patch("subprocess.run", return_value=mock_result):
+            result = assistant.execute_cli("claude", "test prompt")
+
+        assert result == "This is the answer."
+
+    @pytest.mark.description("CLI failure raises 500")
+    def test_cli_failure_raises_500(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLI exit code != 0 raises HTTPException 500."""
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_cli_timeout", 60)
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "Error: something went wrong"
+
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(HTTPException) as exc_info:
+                assistant.execute_cli("claude", "test prompt")
+
+            assert exc_info.value.status_code == 500
+            assert "exit code 1" in exc_info.value.detail
+
+    @pytest.mark.description("CLI timeout raises 500")
+    def test_cli_timeout_raises_500(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLI timeout raises HTTPException 500."""
+        import subprocess
+
+        from voogle import settings as settings_module
+
+        monkeypatch.setattr(settings_module.settings, "local_assistant_cli_timeout", 60)
+
+        with patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=60)
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                assistant.execute_cli("claude", "test prompt")
+
+            assert exc_info.value.status_code == 500
+            assert "timed out" in exc_info.value.detail
+
+
+class TestBuildPrompt:
+    """Tests for prompt building."""
+
+    @pytest.mark.description("Prompt includes all sources with citations")
+    def test_prompt_includes_citations(self) -> None:
+        """Built prompt contains [1], [2] citations with episode/channel info."""
+        sources = [
+            SourceCitation(
+                index=1,
+                episode_title="Episode 1",
+                channel_title="Channel A",
+                start_secs=10.0,
+                end_secs=50.0,
+                text="This is the first fragment.",
+                media_url="http://example.com/ep1.mp3",
+            ),
+            SourceCitation(
+                index=2,
+                episode_title="Episode 2",
+                channel_title="Channel B",
+                start_secs=100.0,
+                end_secs=150.0,
+                text="This is the second fragment.",
+                media_url="http://example.com/ep2.mp3",
+            ),
+        ]
+
+        prompt = assistant.build_prompt("What is the topic?", sources)
+
+        assert "[1]" in prompt
+        assert "[2]" in prompt
+        assert "Episode 1" in prompt
+        assert "Episode 2" in prompt
+        assert "Channel A" in prompt
+        assert "Channel B" in prompt
+        assert "10s-50s" in prompt
+        assert "100s-150s" in prompt
+        assert "This is the first fragment." in prompt
+        assert "This is the second fragment." in prompt
+        assert "What is the topic?" in prompt
+
+    @pytest.mark.description("Prompt handles empty search results")
+    def test_empty_results_prompt(self) -> None:
+        """When search returns no results, prompt explains this."""
+        prompt = assistant.build_prompt("What is the topic?", [])
+
+        assert "no relevant sources" in prompt.lower()
+        assert "What is the topic?" in prompt


### PR DESCRIPTION
## Summary

Closes #33

- **New endpoint**: `GET /assistant/answer_local` - Retrieves fragments via semantic search, builds a prompt with citations, and shells out to `claude` or `codex` CLI for answer generation
- **Zero API spend**: Uses user-installed CLI tools that run on the local machine
- **Defense in depth security**:
  - Feature flag `LOCAL_ASSISTANT_ENABLED=false` (disabled by default)
  - Localhost-only with optional IP allowlist (`LOCAL_ASSISTANT_ALLOWLIST`)
  - No shell injection (subprocess.run with list args)
  - Streamlit warning banner when enabled
- **Configurable settings**: CLI preference, timeout, allowlist

### Response Schema
```json
{
  "answer": "Based on the sources, golf is a sport...",
  "sources": [
    {
      "index": 1,
      "episode_title": "...",
      "channel_title": "...",
      "start_secs": 10.0,
      "end_secs": 50.0,
      "text": "...",
      "media_url": "..."
    }
  ],
  "cli_used": "claude",
  "query": "golf"
}
```

## Test plan

- [x] Unit tests for guard layers (feature flag, localhost check)
- [x] Unit tests for CLI detection and execution
- [x] Unit tests for prompt building with citations
- [x] Integration tests for full endpoint flow
- [x] Integration tests for empty search results
- [x] Integration tests for CLI timeout handling
- [x] All 133 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)