### PR TITLE
#39: Fix local channel media URL generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Format: **WHAT** changed, **WHY** it changed, and any **REASONING** behind decis
 
 ## [Unreleased]
 
+### Fixed
+- **Local channel media URLs use correct path segment** (#39)
+  - `channel_path()` and `channel_folder_name()` now use `local_folder` for local channels
+  - Previously used slugified title+feed which produced malformed paths like `local-channel-`
+  - Local channels now correctly use their `local_folder` value for file storage and URL generation
+  - E2E tests for local channel playback now pass
+
+**WHY**: Local channel media URLs were returning 404 errors because the URL path didn't match where files were stored. This was revealed by #37 (E2E console error detection).
+
+**REASONING**: Local channels have empty `feed` values, so the slugified path was malformed. Using `local_folder` directly is the correct approach since that's where the source files originate and what users expect.
+
 ### Added
 - **Result Map Visualization with 2D Embedding Projection** (#32)
   - New `/media/query/visualize` endpoint returns 2D coordinates for search results

--- a/backend/src/voogle/storage.py
+++ b/backend/src/voogle/storage.py
@@ -34,7 +34,13 @@ def vectordb_path() -> pathlib.Path:
 
 
 def channel_path(channel: media.Channel) -> pathlib.Path:
-    """Return the path where channel media files should be stored."""
+    """Return the path where channel media files should be stored.
+
+    For local channels, uses the local_folder value directly.
+    For podcast channels, uses a slugified combination of title and feed.
+    """
+    if channel.local_folder:
+        return settings.settings.media_folder / str(channel.local_folder)
     fname = f"{slugify(str(channel.title)[:30])}-{slugify(str(channel.feed)[-10:])}"
     return settings.settings.media_folder / fname
 
@@ -71,7 +77,13 @@ async def transcription_file(
 
 
 def channel_folder_name(channel: media.Channel) -> str:
-    """Return the folder name for a channel (without full path)."""
+    """Return the folder name for a channel (without full path).
+
+    For local channels, uses the local_folder value directly.
+    For podcast channels, uses a slugified combination of title and feed.
+    """
+    if channel.local_folder:
+        return str(channel.local_folder)
     return f"{slugify(str(channel.title)[:30])}-{slugify(str(channel.feed)[-10:])}"
 
 

--- a/tests/integration/test_local.py
+++ b/tests/integration/test_local.py
@@ -131,9 +131,8 @@ def test_storage_helper_functions(
     channel_folder = storage.channel_folder_name(local_channel)
     episode_file = storage.episode_filename(local_episode)
 
-    # Channel folder name should be slugified and contain parts of title and feed
-    assert "-" in channel_folder
-    assert "local-test-channel" in channel_folder
+    # For local channels, folder name should match local_folder value
+    assert channel_folder == local_channel.local_folder
 
     # Episode filename should have .mp3 extension
     assert episode_file.endswith(".mp3")


### PR DESCRIPTION
## Summary

- Local channel media URLs now use `local_folder` instead of slugified title+feed
- Fixes 404 errors when playing audio from local channels
- Updates `channel_path()` and `channel_folder_name()` in `storage.py`

Closes #39

## Test plan

- [x] All unit/integration tests pass (180 passed)
- [x] All E2E tests pass (16 passed)
- [x] `test_channel_type_playback[chromium-local-channel]` specifically verifies local channel playback works
- [x] No console errors in browser when playing local channel media

🤖 Generated with [Claude Code](https://claude.com/claude-code)