### PR TITLE
#47: Enable parallel development with deterministic port assignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ output/
 # =============================================================================
 data/
 data-test/
+
+# E2E test manifest is auto-generated from project directory name
+# (enables parallel development across repo copies)
+tests/e2e/manifest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,7 @@ npm run dev                      # Vite dev server with HMR
 ### 2. Docker Dev with Hot Reload (Full Stack)
 
 **Complete dev environment** - All services in Docker with bind mounts for hot reload.
+**Supports parallel development** - Multiple repo copies can run simultaneously.
 
 ```bash
 # First time setup
@@ -93,18 +94,31 @@ cp .env.example .env              # Create your env file
 # Build images (first time or after dependency changes)
 cd infra && make dev-build
 
-# Run all services with hot reload
-make dev-run
+# Run all services with hot reload (auto-derives ports from directory name)
+./infra/dev-up
+
+# Or with options
+./infra/dev-up -d                 # Detached mode
+./infra/dev-up --build            # Rebuild first
 
 # Services auto-reload when you edit files!
 ```
 
-**Ports**:
-- Frontend: http://localhost:80
-- Backend API: http://localhost:81/service/docs
-- Management UI: http://localhost:8501
-- Redis: internal (redis:6379)
-- Qdrant: internal (qdrant:6333)
+**Ports** (auto-derived from directory name for parallel development):
+```bash
+# See your assigned ports
+python infra/dev_ports.py --show
+
+# Example for voogle-copy3:
+#   Frontend:   http://localhost:8110
+#   API:        http://localhost:8111/service/docs
+#   Management: http://localhost:8610
+#   Qdrant:     http://localhost:6363
+```
+
+**Parallel Development**: Ports are deterministically derived from the project directory name.
+Each `voogle-copyN` gets unique ports (offset = N * 10), enabling multiple instances to run
+without conflicts. E2E tests auto-detect the correct ports.
 
 **How it works**:
 - Backend: Mounts `../../backend/` → uvicorn --reload watches files
@@ -334,6 +348,8 @@ voogle/
 ├── infra/                        # Infrastructure & deployment
 │   ├── development/             # Dev environment (compose.yml, .env.example)
 │   ├── production/              # Prod environment (Traefik, replicas)
+│   ├── dev_ports.py             # Port derivation (enables parallel dev)
+│   ├── dev-up                   # Start dev environment with auto-ports
 │   └── makefile                 # Infrastructure commands
 ├── .github/workflows/            # CI/CD
 │   ├── backend.yml              # Lint + Test on PRs

--- a/context/design-principles.md
+++ b/context/design-principles.md
@@ -36,6 +36,16 @@ No duplicated business logic. Config in env vars. Constants defined once.
 - Config: `src/config/` reads env vars, exports typed settings
 - Shared utilities: `src/shared/`
 - Domain logic: Lives in one place, imported where needed
+- Infrastructure: Port derivation in `infra/dev_ports.py` (enables parallel development)
+
+### Parallel Development
+Multiple repo copies can run simultaneously for PR-scoped work on different milestones.
+
+- Ports are derived deterministically from directory name (voogle-copyN → offset N*10)
+- Start dev environment: `./infra/dev-up` (auto-derives ports)
+- View assigned ports: `python infra/dev_ports.py --show`
+- E2E tests auto-detect ports via ManifestReader importing same logic
+- No merge conflicts: manifest.json is gitignored, ports derived at runtime
 
 ### Composition Over Inheritance
 Prefer small, focused functions and classes. Inject dependencies explicitly.

--- a/infra/dev-up
+++ b/infra/dev-up
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Start development environment with auto-derived ports.
+#
+# This script sources ports from dev-ports.py (based on project directory name)
+# then runs docker-compose. This enables multiple repo copies to run in parallel.
+#
+# Usage:
+#   ./infra/dev-up           # Start all services
+#   ./infra/dev-up -d        # Start in detached mode
+#   ./infra/dev-up --build   # Rebuild images first
+#   ./infra/dev-up logs -f   # View logs (any docker-compose command works)
+#
+# To see your assigned ports:
+#   python infra/dev-ports.py --show
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Source port assignments
+eval "$("$PROJECT_ROOT/infra/dev_ports.py")"
+
+# Default to 'up' if no command given
+CMD="${1:-up}"
+shift 2>/dev/null || true
+
+# Show ports on startup for 'up' command
+if [ "$CMD" = "up" ]; then
+    echo "Starting $(basename "$PROJECT_ROOT") development environment"
+    echo "  Frontend:   http://localhost:$VOOGLE_FRONTEND_PORT"
+    echo "  API:        http://localhost:$VITE_API_PORT/service/docs"
+    echo "  Management: http://localhost:$VOOGLE_MANAGEMENT_PORT"
+    echo "  Qdrant:     http://localhost:$VOOGLE_QDRANT_PORT"
+    echo ""
+fi
+
+cd "$PROJECT_ROOT/infra/development"
+exec docker compose "$CMD" "$@"

--- a/infra/dev_ports.py
+++ b/infra/dev_ports.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""
+Deterministic port assignment for parallel Voogle development.
+
+This is the SINGLE SOURCE OF TRUTH for port assignments. It derives ports
+from the project directory name, enabling multiple copies to run simultaneously
+without conflicts.
+
+Port Scheme:
+  - Base: frontend=8080, api=8081, management=8580, qdrant=6333
+  - Each "voogle-copyN" adds offset of N*10
+  - Non-standard names use hash-based offset (0-90 range)
+
+Examples:
+  voogle       -> frontend:8080, api:8081, management:8580, qdrant:6333
+  voogle-copy1 -> frontend:8090, api:8091, management:8590, qdrant:6343
+  voogle-copy2 -> frontend:8100, api:8101, management:8600, qdrant:6353
+  voogle-copy3 -> frontend:8110, api:8111, management:8610, qdrant:6363
+
+Usage:
+  # Shell: export environment variables
+  eval $(python infra/dev-ports.py)
+  docker compose up
+
+  # Python: import and use
+  from infra.dev_ports import get_ports
+  ports = get_ports()
+
+  # Show ports without exporting
+  python infra/dev-ports.py --show
+"""
+
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+class Ports(NamedTuple):
+    """Port assignments for a Voogle development instance."""
+
+    frontend: int
+    api: int
+    management: int
+    qdrant: int
+
+    def to_env_vars(self) -> dict[str, str]:
+        """Return as environment variable dict for docker-compose."""
+        return {
+            "VOOGLE_FRONTEND_PORT": str(self.frontend),
+            "VITE_API_PORT": str(self.api),
+            "VOOGLE_MANAGEMENT_PORT": str(self.management),
+            "VOOGLE_QDRANT_PORT": str(self.qdrant),
+        }
+
+    def to_manifest(self) -> dict[str, str]:
+        """Return as manifest.json content for E2E tests."""
+        return {
+            "management_url": f"http://localhost:{self.management}",
+            "frontend_url": f"http://localhost:{self.frontend}",
+            "api_url": f"http://localhost:{self.api}",
+            "admin_username": "voogle-admin",
+            "admin_password": "*audio*search*engine",
+        }
+
+
+# Base ports (no offset)
+BASE_FRONTEND = 8080
+BASE_API = 8081
+BASE_MANAGEMENT = 8580
+BASE_QDRANT = 6333
+
+
+def _get_project_root() -> Path:
+    """Find project root by looking for CLAUDE.md marker."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        if (current / "CLAUDE.md").exists():
+            return current
+        current = current.parent
+    # Fallback to parent of infra/
+    return Path(__file__).resolve().parent.parent
+
+
+def _extract_copy_number(dirname: str) -> int | None:
+    """Extract copy number from directory name like 'voogle-copy3'."""
+    match = re.search(r"voogle-copy(\d+)", dirname, re.IGNORECASE)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def _hash_to_offset(dirname: str) -> int:
+    """Generate deterministic offset (0-9) from directory name hash."""
+    h = hashlib.md5(dirname.encode()).hexdigest()
+    return (int(h[:8], 16) % 10) * 10
+
+
+def get_offset(project_root: Path | None = None) -> int:
+    """
+    Get port offset based on project directory name.
+
+    Returns offset in range [0, 90] that's added to base ports.
+    """
+    if project_root is None:
+        project_root = _get_project_root()
+
+    dirname = project_root.name.lower()
+
+    # Check for explicit copy number
+    copy_num = _extract_copy_number(dirname)
+    if copy_num is not None:
+        return copy_num * 10
+
+    # Base voogle directory (no copy suffix)
+    if dirname == "voogle":
+        return 0
+
+    # Non-standard name: use hash-based offset
+    return _hash_to_offset(dirname)
+
+
+def get_ports(project_root: Path | None = None) -> Ports:
+    """Get port assignments for this project instance."""
+    offset = get_offset(project_root)
+    return Ports(
+        frontend=BASE_FRONTEND + offset,
+        api=BASE_API + offset,
+        management=BASE_MANAGEMENT + offset,
+        qdrant=BASE_QDRANT + offset,
+    )
+
+
+def print_shell_exports(ports: Ports) -> None:
+    """Print shell export commands for eval."""
+    for name, value in ports.to_env_vars().items():
+        print(f"export {name}={value}")
+
+
+def print_human_readable(ports: Ports, project_root: Path) -> None:
+    """Print human-readable port information."""
+    offset = get_offset(project_root)
+    print(f"Project: {project_root.name}")
+    print(f"Offset:  {offset}")
+    print()
+    print("Ports:")
+    print(f"  Frontend:   http://localhost:{ports.frontend}")
+    print(f"  API:        http://localhost:{ports.api}")
+    print(f"  Management: http://localhost:{ports.management}")
+    print(f"  Qdrant:     http://localhost:{ports.qdrant}")
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    project_root = _get_project_root()
+    ports = get_ports(project_root)
+
+    if "--show" in sys.argv or "-s" in sys.argv:
+        print_human_readable(ports, project_root)
+    elif "--json" in sys.argv:
+        import json
+
+        print(json.dumps(ports.to_manifest(), indent=2))
+    elif "--env-file" in sys.argv:
+        # Output in .env file format
+        for name, value in ports.to_env_vars().items():
+            print(f"{name}={value}")
+    else:
+        # Default: shell export format for eval
+        print_shell_exports(ports)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/development/compose.yml
+++ b/infra/development/compose.yml
@@ -25,7 +25,7 @@ services:
     environment:
       - EMBEDDINGS_PROVIDER_OVERRIDE=local
     ports:
-      - ${VITE_API_PORT:-81}:80
+      - ${VITE_API_PORT:?Run: eval \$(python ../../infra/dev-ports.py)}:80
     command: uvicorn src.voogle.main:app --reload --reload-dir /backend/src --host 0.0.0.0 --port 80
     volumes:
       - ../../backend/:/backend/
@@ -43,7 +43,7 @@ services:
       backend:
         condition: service_healthy
     ports:
-      - ${VOOGLE_FRONTEND_PORT:-80}:5173
+      - ${VOOGLE_FRONTEND_PORT:?Run: eval \$(python ../../infra/dev-ports.py)}:5173
     build:
       context: ../../frontend
       dockerfile: dockerfile.dev
@@ -73,7 +73,7 @@ services:
     env_file:
       - .env
     ports:
-      - ${VOOGLE_MANAGEMENT_PORT:-8501}:8501
+      - ${VOOGLE_MANAGEMENT_PORT:?Run: eval \$(python ../../infra/dev-ports.py)}:8501
     command: streamlit run src/voogle/management/🏠-Home.py
     volumes:
       - ../../backend/:/backend/
@@ -111,7 +111,7 @@ services:
     <<: *defaults
     image: qdrant/qdrant:v1.12.5
     ports:
-      - 6333:6333
+      - ${VOOGLE_QDRANT_PORT:?Run: eval \$(python ../../infra/dev-ports.py)}:6333
     volumes:
       - ../../data/qdrant/:/qdrant/storage
     stop_grace_period: 30s  # Give Qdrant time to flush data to disk on shutdown

--- a/tests/e2e/manifest.json
+++ b/tests/e2e/manifest.json
@@ -1,7 +1,0 @@
-{
-  "management_url": "http://localhost:8501",
-  "frontend_url": "http://localhost:80",
-  "api_url": "http://localhost:81",
-  "admin_username": "voogle-admin",
-  "admin_password": "*audio*search*engine"
-}

--- a/tests/e2e/shared/manifest.py
+++ b/tests/e2e/shared/manifest.py
@@ -1,24 +1,73 @@
 # Copyright (c) 2025-2026 Voogle Contributors
 # All rights reserved.
 
-"""Manifest reader for test configuration."""
+"""Manifest reader for test configuration.
+
+Auto-derives port configuration from project directory name, enabling
+parallel development across multiple repo copies without conflicts.
+
+Priority:
+1. Environment variables (VOOGLE_FRONTEND_PORT, VITE_API_PORT, etc.)
+2. manifest.json file (if exists)
+3. Auto-derived from directory name via infra/dev-ports.py logic
+"""
 
 import json
+import os
+import sys
 from pathlib import Path
 from typing import Any
 
+# Add infra/ to path for importing dev-ports
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT / "infra"))
+
+from dev_ports import get_ports  # noqa: E402
+
 
 class ManifestReader:
-    """Read test configuration from manifest.json."""
+    """Read test configuration from manifest or auto-derive from ports."""
 
     MANIFEST_FILENAME = "manifest.json"
 
     def __init__(self, manifest_dir: str | Path) -> None:
         self.__manifest_dir = Path(manifest_dir)
-        manifest_path = self.__manifest_dir / self.MANIFEST_FILENAME
+        self.__manifest_content = self._load_manifest()
 
-        with open(manifest_path, encoding="utf-8") as f:
-            self.__manifest_content = json.loads(f.read())
+    def _load_manifest(self) -> dict[str, Any]:
+        """Load manifest from env vars, file, or auto-derive from ports."""
+        # Priority 1: Environment variables override everything
+        env_manifest = self._from_env_vars()
+        if env_manifest:
+            return env_manifest
+
+        # Priority 2: manifest.json file if it exists
+        manifest_path = self.__manifest_dir / self.MANIFEST_FILENAME
+        if manifest_path.exists():
+            with open(manifest_path, encoding="utf-8") as f:
+                return json.loads(f.read())
+
+        # Priority 3: Auto-derive from project directory name
+        return get_ports(_PROJECT_ROOT).to_manifest()
+
+    def _from_env_vars(self) -> dict[str, Any] | None:
+        """Build manifest from environment variables if set."""
+        frontend_port = os.environ.get("VOOGLE_FRONTEND_PORT")
+        api_port = os.environ.get("VITE_API_PORT")
+        management_port = os.environ.get("VOOGLE_MANAGEMENT_PORT")
+
+        # Only use env vars if at least the main ports are set
+        if frontend_port and api_port:
+            return {
+                "frontend_url": f"http://localhost:{frontend_port}",
+                "api_url": f"http://localhost:{api_port}",
+                "management_url": f"http://localhost:{management_port or '8501'}",
+                "admin_username": os.environ.get("ADMIN_USERNAME", "voogle-admin"),
+                "admin_password": os.environ.get(
+                    "ADMIN_PASSWORD", "*audio*search*engine"
+                ),
+            }
+        return None
 
     def get_if_exists_in_manifest(self, k: str) -> dict[str, Any] | str | None:
         return self.__manifest_content.get(k)


### PR DESCRIPTION
## Summary

- Derive port numbers from project directory name (voogle-copyN → offset N*10)
- Single source of truth: `infra/dev_ports.py` (Python script, importable + CLI)
- Wrapper script: `./infra/dev-up` sources ports and runs docker-compose
- E2E tests auto-detect ports via updated ManifestReader

## Port Scheme

| Directory | Frontend | API | Management | Qdrant |
|-----------|----------|-----|------------|--------|
| voogle | 8080 | 8081 | 8580 | 6333 |
| voogle-copy1 | 8090 | 8091 | 8590 | 6343 |
| voogle-copy2 | 8100 | 8101 | 8600 | 6353 |
| voogle-copy3 | 8110 | 8111 | 8610 | 6363 |

## Usage

```bash
# Start dev environment (ports auto-derived from directory name)
./infra/dev-up

# See your assigned ports
python infra/dev_ports.py --show

# Outputs for voogle-copy3:
#   Frontend:   http://localhost:8110
#   API:        http://localhost:8111
#   Management: http://localhost:8610
#   Qdrant:     http://localhost:6363
```

## Test plan

- [x] `python infra/dev_ports.py --show` displays correct ports for directory
- [x] ManifestReader auto-derives ports when no manifest.json exists
- [x] All unit/component tests pass: `pytest tests/ --ignore=tests/e2e -v`
- [ ] E2E tests pass with running dev environment: `pytest tests/e2e -v`

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)