### PR TITLE
#49: Update quickstart compose to use ghcr.io images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Format: **WHAT** changed, **WHY** it changed, and any **REASONING** behind decis
 
 ## [Unreleased]
 
+### Changed
+- **Quick start compose now uses ghcr.io images** (#49)
+  - Updated `compose.quickstart.yml` to pull from `ghcr.io/jbraseth/voogle-backend:latest` and `ghcr.io/jbraseth/voogle-ui:latest`
+  - Replaced outdated `docker.io/unmonoqueteclea/voogle-backend:3.2.0` and `docker.io/unmonoqueteclea/voogle-ui:0.6.0`
+  - Frontend container port updated from 5173 (dev) to 80 (production nginx)
+  - Removed `--reload` flag from backend command (not needed for production images)
+  - Updated `readme.md` quick start section with correct commands and image references
+
+**WHY**: The old Docker Hub images from the archived Voilib project are stale (v3.2.0/v0.6.0) and missing 6+ months of bug fixes. New users following the README would get outdated software.
+
+**REASONING**: ghcr.io images are built from current main branch via #43 workflow. Public images require no authentication to pull. Using `latest` tag ensures users always get current code.
+
 ### Added
 - **GitHub Container Registry builds with manual trigger** (#43)
   - New `.github/workflows/build-images.yml` workflow with `workflow_dispatch` trigger

--- a/compose.quickstart.yml
+++ b/compose.quickstart.yml
@@ -2,10 +2,10 @@ name: voogle
 
 services:
   backend:
-    image: docker.io/unmonoqueteclea/voogle-backend:3.2.0
+    image: ghcr.io/jbraseth/voogle-backend:latest
     ports:
       - ${VOOGLE_API_PORT:-81}:80
-    command:  uvicorn src.voogle.main:app --reload --host 0.0.0.0 --port 80
+    command: uvicorn src.voogle.main:app --host 0.0.0.0 --port 80
     volumes:
       - ./data/:/data/
     healthcheck:
@@ -15,22 +15,20 @@ services:
       retries: 50
 
   frontend:
-    image: docker.io/unmonoqueteclea/voogle-ui:0.6.0
+    image: ghcr.io/jbraseth/voogle-ui:latest
     depends_on:
       backend:
         condition: service_healthy
     ports:
-      - ${VOOGLE_FRONTEND_PORT:-80}:5173
-    environment:
-      - VITE_API_PORT=${VOOGLE_API_PORT:-81}
+      - ${VOOGLE_FRONTEND_PORT:-80}:80
     healthcheck:
-      test: ["CMD", "curl", "-f", "0.0.0.0:5173"]
+      test: ["CMD", "curl", "-f", "0.0.0.0:80"]
       interval: 6s
       timeout: 10s
       retries: 50
 
   management:
-    image: docker.io/unmonoqueteclea/voogle-backend:3.2.0
+    image: ghcr.io/jbraseth/voogle-backend:latest
     ports:
       - ${VOOGLE_MANAGEMENT_PORT:-8501}:8501
     entrypoint: ""
@@ -48,7 +46,7 @@ services:
       retries: 30
 
   worker:
-    image: docker.io/unmonoqueteclea/voogle-backend:3.2.0
+    image: ghcr.io/jbraseth/voogle-backend:latest
     depends_on:
       redis:
         condition: service_healthy

--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,22 @@ users to index their own audio files.
 You can run **your own instance** of Voogle in your server, it
 doesn't depend on any external paid service.
 
+```bash
+# Pull and start all services
+docker compose -f compose.quickstart.yml up -d
+
+# View logs
+docker compose -f compose.quickstart.yml logs -f
+
+# Access the application
+# Frontend: http://localhost:80
+# API: http://localhost:81/docs
+# Management: http://localhost:8501
 ```
-mkdir voogle && cd "voogle"
-curl https://raw.githubusercontent.com/jbraseth/voogle/main/infra/production/compose.yml -o compose.yml
-docker compose up
-```
+
+Images are hosted on GitHub Container Registry and require no authentication:
+- `ghcr.io/jbraseth/voogle-backend:latest`
+- `ghcr.io/jbraseth/voogle-ui:latest`
 
 You will need an admin user and password. By default user
 `voogle-admin` with password `*audio*search*engine` will be created.


### PR DESCRIPTION
## Summary

- Updated `compose.quickstart.yml` to use ghcr.io images instead of stale Docker Hub images
- Backend/worker/management: `ghcr.io/jbraseth/voogle-backend:latest`
- Frontend: `ghcr.io/jbraseth/voogle-ui:latest`
- Frontend port changed from 5173 (dev) to 80 (production nginx)
- Removed `--reload` flag from backend (not needed for production images)
- Updated `readme.md` quick start section with correct commands

## Test plan

- [x] `ruff check .` passes
- [x] `pytest tests/ --ignore=tests/e2e` passes (180 passed)
- [x] `docker pull ghcr.io/jbraseth/voogle-backend:latest` works without auth
- [x] `docker pull ghcr.io/jbraseth/voogle-ui:latest` works without auth
- [x] No `unmonoqueteclea` image references in compose.quickstart.yml
- [x] `docker compose -f compose.quickstart.yml up -d` starts all services (manual verification)

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)