### PR TITLE
feat(D6): Implement Graceful Degradation UI Hints

### DIFF
--- a/backend/src/voogle/core/__init__.py
+++ b/backend/src/voogle/core/__init__.py
@@ -7,7 +7,7 @@ This module exports the foundational data structures used throughout the
 application for representing searchable content.
 """
 from voogle.core.corpus import Corpus
-from voogle.core.fragment import ContentType, Fragment
+from voogle.core.fragment import ContentType, Fragment, LocationConfidence
 from voogle.core.location import (
     CodeLocation,
     ElementSelectorLocation,
@@ -27,6 +27,7 @@ __all__ = [
     "Fragment",
     "ImageRegionLocation",
     "Location",
+    "LocationConfidence",
     "LocationType",
     "PageBboxLocation",
     "SlideLocation",

--- a/backend/src/voogle/core/fragment.py
+++ b/backend/src/voogle/core/fragment.py
@@ -9,10 +9,19 @@ polymorphic location support for different content types.
 
 This module also provides content-addressed ID generation for fragments,
 enabling stable IDs for change detection and deduplication.
+
+Graceful Degradation:
+    Fragments include metadata for graceful UI degradation when source
+    locations become unavailable:
+    - location_confidence: Indicates reliability of the location
+    - fallback_url: Alternative URL when primary is unavailable
+    - archive_url: Archive.org snapshot URL for broken sources
+    - last_known_good: Timestamp when location was last verified
 """
 import hashlib
 import json
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import Any, Optional
 
@@ -29,6 +38,26 @@ class ContentType(Enum):
     SLIDE = "slide"
     TEXT = "text"
     EMAIL = "email"
+
+
+class LocationConfidence(Enum):
+    """Confidence level for fragment location availability.
+
+    Used by clients to decide how to present location-dependent features.
+    For example, a video player button might be disabled when confidence
+    is LOW or UNAVAILABLE.
+
+    Attributes:
+        HIGH: Location verified within 24 hours, highly reliable.
+        MEDIUM: Location verified within 7 days, likely available.
+        LOW: Location not verified recently or had intermittent failures.
+        UNAVAILABLE: Location is known to be broken or inaccessible.
+    """
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    UNAVAILABLE = "unavailable"
 
 
 @dataclass(frozen=True)
@@ -49,6 +78,15 @@ class Fragment:
         deep_link: URL or path to directly access this fragment in context.
             None if not available.
         metadata: Additional source-specific metadata as key-value pairs.
+        location_confidence: Confidence level for location availability.
+            Defaults to HIGH for newly indexed content. Used by clients
+            to gracefully degrade UI when locations may be unavailable.
+        fallback_url: Alternative URL to use when primary location fails.
+            May point to a different CDN, mirror, or cached version.
+        archive_url: Archive.org Wayback Machine URL for this content.
+            Populated when original source becomes unavailable.
+        last_known_good: Timestamp when location was last verified accessible.
+            None if never validated. Used to calculate location_confidence.
     """
 
     id: str
@@ -59,6 +97,10 @@ class Fragment:
     location: Optional[Any] = None
     deep_link: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    location_confidence: LocationConfidence = LocationConfidence.HIGH
+    fallback_url: Optional[str] = None
+    archive_url: Optional[str] = None
+    last_known_good: Optional[datetime] = None
 
     def __post_init__(self) -> None:
         """Validate fragment data after initialization."""

--- a/backend/src/voogle/services/search.py
+++ b/backend/src/voogle/services/search.py
@@ -26,7 +26,7 @@ from qdrant_client import models
 
 from voogle import embedding as emb
 from voogle import vector
-from voogle.core.fragment import ContentType
+from voogle.core.fragment import ContentType, LocationConfidence
 from voogle.embedding.sparse import SparseEncoder, get_sparse_encoder
 from voogle.vector_schema import VectorName
 
@@ -98,6 +98,12 @@ class SearchResult:
         end_time: End time in seconds (for audio/video).
         corpus_id: Corpus this result belongs to.
         metadata: Additional metadata fields.
+        location_confidence: Confidence level for location availability.
+            Clients should use this to gracefully degrade UI when
+            location may be unavailable.
+        fallback_url: Alternative URL if primary location is unavailable.
+        archive_url: Archive.org URL for broken sources.
+        last_known_good: ISO timestamp when location was last verified.
     """
 
     id: str
@@ -109,6 +115,10 @@ class SearchResult:
     end_time: Optional[float] = None
     corpus_id: Optional[str] = None
     metadata: dict = field(default_factory=dict)
+    location_confidence: LocationConfidence = LocationConfidence.HIGH
+    fallback_url: Optional[str] = None
+    archive_url: Optional[str] = None
+    last_known_good: Optional[str] = None
 
 
 @dataclass
@@ -652,6 +662,10 @@ class SearchService:
                     end_time=original.end_time,
                     corpus_id=original.corpus_id,
                     metadata=original.metadata,
+                    location_confidence=original.location_confidence,
+                    fallback_url=original.fallback_url,
+                    archive_url=original.archive_url,
+                    last_known_good=original.last_known_good,
                 )
             )
 
@@ -680,6 +694,13 @@ class SearchService:
             start_time = payload.get("start_time") or payload.get("start_secs")
             end_time = payload.get("end_time") or payload.get("end_secs")
 
+            # Extract graceful degradation fields
+            location_confidence_str = payload.get("location_confidence", "high")
+            try:
+                location_confidence = LocationConfidence(location_confidence_str)
+            except ValueError:
+                location_confidence = LocationConfidence.HIGH
+
             results.append(
                 SearchResult(
                     id=str(point.id),
@@ -704,8 +725,16 @@ class SearchService:
                             "end_secs",
                             "source_type",
                             "corpus_id",
+                            "location_confidence",
+                            "fallback_url",
+                            "archive_url",
+                            "last_known_good",
                         }
                     },
+                    location_confidence=location_confidence,
+                    fallback_url=payload.get("fallback_url"),
+                    archive_url=payload.get("archive_url"),
+                    last_known_good=payload.get("last_known_good"),
                 )
             )
 

--- a/tests/unit/test_graceful_degradation.py
+++ b/tests/unit/test_graceful_degradation.py
@@ -1,0 +1,330 @@
+# Copyright (c) 2025-2026 Voogle Contributors
+# All rights reserved.
+
+"""Unit tests for graceful degradation UI hints.
+
+Tests the LocationConfidence enum and graceful degradation fields
+on Fragment and SearchResult dataclasses.
+"""
+from datetime import datetime, timezone
+
+import pytest
+from voogle.core import ContentType, Fragment, LocationConfidence
+from voogle.services.search import SearchResult
+
+pytestmark = pytest.mark.unit
+
+
+class TestLocationConfidence:
+    """Tests for LocationConfidence enum."""
+
+    @pytest.mark.description("All location confidence levels have string values")
+    def test_location_confidence_values(self) -> None:
+        assert LocationConfidence.HIGH.value == "high"
+        assert LocationConfidence.MEDIUM.value == "medium"
+        assert LocationConfidence.LOW.value == "low"
+        assert LocationConfidence.UNAVAILABLE.value == "unavailable"
+
+    @pytest.mark.description("LocationConfidence can be created from string value")
+    def test_location_confidence_from_value(self) -> None:
+        assert LocationConfidence("high") == LocationConfidence.HIGH
+        assert LocationConfidence("medium") == LocationConfidence.MEDIUM
+        assert LocationConfidence("low") == LocationConfidence.LOW
+        assert LocationConfidence("unavailable") == LocationConfidence.UNAVAILABLE
+
+    @pytest.mark.description("Invalid LocationConfidence value raises ValueError")
+    def test_invalid_location_confidence_raises(self) -> None:
+        with pytest.raises(ValueError):
+            LocationConfidence("invalid")
+
+
+class TestFragmentGracefulDegradation:
+    """Tests for graceful degradation fields on Fragment."""
+
+    @pytest.mark.description("Fragment defaults location_confidence to HIGH")
+    def test_default_location_confidence(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+        )
+        assert fragment.location_confidence == LocationConfidence.HIGH
+
+    @pytest.mark.description("Fragment defaults fallback_url to None")
+    def test_default_fallback_url(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+        )
+        assert fragment.fallback_url is None
+
+    @pytest.mark.description("Fragment defaults archive_url to None")
+    def test_default_archive_url(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+        )
+        assert fragment.archive_url is None
+
+    @pytest.mark.description("Fragment defaults last_known_good to None")
+    def test_default_last_known_good(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+        )
+        assert fragment.last_known_good is None
+
+    @pytest.mark.description("Fragment accepts custom location_confidence")
+    def test_custom_location_confidence(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+            location_confidence=LocationConfidence.LOW,
+        )
+        assert fragment.location_confidence == LocationConfidence.LOW
+
+    @pytest.mark.description("Fragment accepts fallback_url")
+    def test_fallback_url(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+            fallback_url="https://cdn.example.com/backup.mp3",
+        )
+        assert fragment.fallback_url == "https://cdn.example.com/backup.mp3"
+
+    @pytest.mark.description("Fragment accepts archive_url")
+    def test_archive_url(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+            archive_url="https://web.archive.org/web/20250101/example.com/audio.mp3",
+        )
+        assert fragment.archive_url == "https://web.archive.org/web/20250101/example.com/audio.mp3"
+
+    @pytest.mark.description("Fragment accepts last_known_good timestamp")
+    def test_last_known_good(self) -> None:
+        now = datetime.now(timezone.utc)
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.AUDIO,
+            last_known_good=now,
+        )
+        assert fragment.last_known_good == now
+
+    @pytest.mark.description("Fragment with all graceful degradation fields")
+    def test_all_graceful_degradation_fields(self) -> None:
+        now = datetime.now(timezone.utc)
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.VIDEO,
+            location={"start": 30.0, "end": 45.0},
+            deep_link="https://example.com/video?t=30",
+            location_confidence=LocationConfidence.MEDIUM,
+            fallback_url="https://cdn.example.com/video.mp4",
+            archive_url="https://web.archive.org/web/20250101/example.com/video.mp4",
+            last_known_good=now,
+        )
+        assert fragment.location_confidence == LocationConfidence.MEDIUM
+        assert fragment.fallback_url == "https://cdn.example.com/video.mp4"
+        assert fragment.archive_url == "https://web.archive.org/web/20250101/example.com/video.mp4"
+        assert fragment.last_known_good == now
+
+    @pytest.mark.description("Fragment with UNAVAILABLE confidence indicates broken location")
+    def test_unavailable_confidence(self) -> None:
+        fragment = Fragment(
+            id="test-123",
+            text="Hello world",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.DOCUMENT,
+            location_confidence=LocationConfidence.UNAVAILABLE,
+            archive_url="https://web.archive.org/web/20250101/example.com/doc.pdf",
+        )
+        assert fragment.location_confidence == LocationConfidence.UNAVAILABLE
+        assert fragment.archive_url is not None
+
+
+class TestSearchResultGracefulDegradation:
+    """Tests for graceful degradation fields on SearchResult."""
+
+    @pytest.mark.description("SearchResult defaults location_confidence to HIGH")
+    def test_default_location_confidence(self) -> None:
+        result = SearchResult(
+            id="result-1",
+            score=0.95,
+            text="Fragment text",
+            source_id="episode-123",
+        )
+        assert result.location_confidence == LocationConfidence.HIGH
+
+    @pytest.mark.description("SearchResult defaults fallback_url to None")
+    def test_default_fallback_url(self) -> None:
+        result = SearchResult(
+            id="result-1",
+            score=0.95,
+            text="Fragment text",
+            source_id="episode-123",
+        )
+        assert result.fallback_url is None
+
+    @pytest.mark.description("SearchResult defaults archive_url to None")
+    def test_default_archive_url(self) -> None:
+        result = SearchResult(
+            id="result-1",
+            score=0.95,
+            text="Fragment text",
+            source_id="episode-123",
+        )
+        assert result.archive_url is None
+
+    @pytest.mark.description("SearchResult defaults last_known_good to None")
+    def test_default_last_known_good(self) -> None:
+        result = SearchResult(
+            id="result-1",
+            score=0.95,
+            text="Fragment text",
+            source_id="episode-123",
+        )
+        assert result.last_known_good is None
+
+    @pytest.mark.description("SearchResult accepts custom graceful degradation fields")
+    def test_all_graceful_degradation_fields(self) -> None:
+        result = SearchResult(
+            id="result-1",
+            score=0.95,
+            text="Fragment text",
+            source_id="episode-123",
+            source_type="audio",
+            start_time=30.0,
+            end_time=45.0,
+            location_confidence=LocationConfidence.LOW,
+            fallback_url="https://cdn.example.com/backup.mp3",
+            archive_url="https://web.archive.org/web/20250101/example.com/audio.mp3",
+            last_known_good="2025-01-01T12:00:00Z",
+        )
+        assert result.location_confidence == LocationConfidence.LOW
+        assert result.fallback_url == "https://cdn.example.com/backup.mp3"
+        assert result.archive_url == "https://web.archive.org/web/20250101/example.com/audio.mp3"
+        assert result.last_known_good == "2025-01-01T12:00:00Z"
+
+    @pytest.mark.description("SearchResult with UNAVAILABLE confidence for broken source")
+    def test_unavailable_confidence(self) -> None:
+        result = SearchResult(
+            id="result-1",
+            score=0.95,
+            text="Fragment text",
+            source_id="episode-123",
+            location_confidence=LocationConfidence.UNAVAILABLE,
+            archive_url="https://web.archive.org/web/20250101/example.com/episode.mp3",
+        )
+        assert result.location_confidence == LocationConfidence.UNAVAILABLE
+        assert result.archive_url is not None
+
+
+class TestLocationConfidenceUseCases:
+    """Tests demonstrating graceful degradation use cases."""
+
+    @pytest.mark.description("High confidence indicates recently verified location")
+    def test_high_confidence_scenario(self) -> None:
+        """A location verified within 24 hours should have HIGH confidence."""
+        recent_check = datetime(2025, 1, 13, 10, 0, 0, tzinfo=timezone.utc)
+        fragment = Fragment(
+            id="test-1",
+            text="Recently verified content",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.VIDEO,
+            location_confidence=LocationConfidence.HIGH,
+            last_known_good=recent_check,
+        )
+        assert fragment.location_confidence == LocationConfidence.HIGH
+        # Client can confidently show play button
+
+    @pytest.mark.description("Medium confidence indicates stale but likely valid location")
+    def test_medium_confidence_scenario(self) -> None:
+        """A location not verified for a few days should have MEDIUM confidence."""
+        older_check = datetime(2025, 1, 7, 10, 0, 0, tzinfo=timezone.utc)
+        fragment = Fragment(
+            id="test-1",
+            text="Older verified content",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.VIDEO,
+            location_confidence=LocationConfidence.MEDIUM,
+            last_known_good=older_check,
+        )
+        assert fragment.location_confidence == LocationConfidence.MEDIUM
+        # Client may show play button with "may not be available" tooltip
+
+    @pytest.mark.description("Low confidence indicates unreliable location")
+    def test_low_confidence_scenario(self) -> None:
+        """A location with intermittent failures should have LOW confidence."""
+        fragment = Fragment(
+            id="test-1",
+            text="Unreliable content",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.VIDEO,
+            location_confidence=LocationConfidence.LOW,
+            fallback_url="https://cdn.example.com/backup.mp4",
+        )
+        assert fragment.location_confidence == LocationConfidence.LOW
+        # Client should show warning and possibly try fallback first
+
+    @pytest.mark.description("Unavailable confidence indicates broken location with archive fallback")
+    def test_unavailable_with_archive_scenario(self) -> None:
+        """A broken location should have UNAVAILABLE confidence with archive URL."""
+        fragment = Fragment(
+            id="test-1",
+            text="Content from broken source",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.VIDEO,
+            location_confidence=LocationConfidence.UNAVAILABLE,
+            archive_url="https://web.archive.org/web/20250101/example.com/video.mp4",
+        )
+        assert fragment.location_confidence == LocationConfidence.UNAVAILABLE
+        assert fragment.archive_url is not None
+        # Client should disable play button but offer archive link
+
+    @pytest.mark.description("Unavailable confidence without fallback")
+    def test_unavailable_without_fallback_scenario(self) -> None:
+        """A broken location with no fallback should clearly indicate unavailability."""
+        fragment = Fragment(
+            id="test-1",
+            text="Content from broken source",
+            score=0.9,
+            source_id="src-1",
+            source_type=ContentType.VIDEO,
+            location_confidence=LocationConfidence.UNAVAILABLE,
+        )
+        assert fragment.location_confidence == LocationConfidence.UNAVAILABLE
+        assert fragment.fallback_url is None
+        assert fragment.archive_url is None
+        # Client should disable play button and show "source unavailable"


### PR DESCRIPTION
## Summary

Add metadata for graceful UI degradation when locations break:

- **LocationConfidence enum** (high/medium/low/unavailable) - indicates reliability of fragment locations
- **fallback_url** - alternative URL when primary location is unavailable  
- **archive_url** - Archive.org Wayback Machine URL for broken sources
- **last_known_good** - timestamp when location was last verified accessible

These fields are added to both `Fragment` dataclass and `SearchResult` for consistent API responses.

## Changes

- `backend/src/voogle/core/fragment.py`: Added `LocationConfidence` enum and graceful degradation fields to `Fragment`
- `backend/src/voogle/core/__init__.py`: Export `LocationConfidence`
- `backend/src/voogle/services/search.py`: Added graceful degradation fields to `SearchResult`, updated `_convert_results` and RRF fusion

## Test plan

- [x] 24 new unit tests covering all graceful degradation fields and use cases
- [x] Existing Fragment and SearchResult tests pass (45 tests)
- [x] Acceptance criteria: `location_confidence` field verified in Fragment dataclass
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)